### PR TITLE
Alexlib clean ray tracing

### DIFF
--- a/liboptv/include/calibration.h
+++ b/liboptv/include/calibration.h
@@ -7,8 +7,13 @@
         pp.165-168
 */
 
+#include "tracking_frame_buf.h"
+
 #ifndef CALIBRATION_H
 #define CALIBRATION_H
+
+#define PI 3.14159
+
 
 typedef	double	Dmatrix[3][3];	/* 3 x 3 rotation matrix */
 
@@ -48,10 +53,11 @@ typedef struct {
 
 
 
-int write_ori(Exterior Ex, Interior I, Glass G, ap_52 ap, char *filename, 
-    char *add_file);
-int read_ori (Exterior Ex[], Interior I[], Glass G[], char *ori_file, 
-    ap_52 addp[], char *add_file, char *add_fallback);
+int write_ori(Exterior Ex, Interior I, Glass G, ap_52 ap, char *filename, \
+char *add_file);
+int read_ori (Exterior *Ex, Interior *I, Glass *G, char *ori_file, ap_52 *addp, 
+    char *add_file, char *add_fallback);
+
 int compare_exterior(Exterior *e1, Exterior *e2);
 int compare_interior(Interior *i1, Interior *i2);
 int compare_glass(Glass *g1, Glass *g2);

--- a/liboptv/include/lsqadj.h
+++ b/liboptv/include/lsqadj.h
@@ -1,0 +1,24 @@
+/* Forward declarations for matrix operations defined in lsqadj.c */
+
+#ifndef LSQADJ_H
+#define LSQADJ_H
+
+#include <stdlib.h>
+#include <stdio.h>
+
+
+void ata(double *a, double *ata, int m, int n);
+void ata_v2(double *a, double *ata, int m, int n, int n_large);
+void atl(double *a, double *u, double *l, int m, int n);
+void atl_v2 (double *u, double *a, double *l, int m, int n, int n_large);
+
+
+void matinv(double *a, int n);
+void matinv_v2 (double *a, int n, int n_large);
+void matmul(double *a, double *b, double *c, int m, int n, int k);
+void matmul_v2 (double *a, double *b, double *c, int m,int n,int k,\
+int m_large, int n_large);
+void transp (double a[], int m, int n);
+void mat_transpose(double *mat1, double *mat2, int m, int n);
+
+#endif

--- a/liboptv/include/ray_tracing.h
+++ b/liboptv/include/ray_tracing.h
@@ -1,0 +1,34 @@
+/*  Objects related to calibration: exterior and interior parameters, glass
+    parameters. A Calibration object to rule them all and find them. 
+
+    References:
+    [1] Th. Dracos (editor). Three-Dimensional Velocity and Vorticity Measuring
+        and Image Analysis Techniques. Kluwer Academic Publishers. 1996. 
+        pp.165-168
+*/
+
+#ifndef RAYTRACING_H
+#define RAYTRACING_H
+
+#include "parameters.h"
+#include "calibration.h"
+#include "tracking_frame_buf.h"
+#include "lsqadj.h"
+#include "math.h"
+
+/* TODO: replace local functions by vec_utils */
+
+void modu(double a[3], double *m);
+void norm_cross(double a[3], double b[3], double *n1, double *n2, double *n3);
+void dot(double a[3], double b[3], double *d);
+
+
+
+void ray_tracing_v2 (double x, double y,Exterior Ex, Interior I, Glass G, mm_np mm,\
+double *Xb2, double *Yb2, double *Zb2, double *a3, double *b3, double *c3); 
+
+
+
+
+#endif
+

--- a/liboptv/src/CMakeLists.txt
+++ b/liboptv/src/CMakeLists.txt
@@ -1,7 +1,6 @@
 
 include_directories("../include/")
-add_library (optv SHARED tracking_frame_buf.c calibration.c parameters.c)
-add_library (optv SHARED tracking_frame_buf.c parameters.c)
+add_library (optv SHARED tracking_frame_buf.c calibration.c parameters.c ray_tracing.c lsqadj.c)
 
 if(UNIX)
   target_link_libraries(optv m)

--- a/liboptv/src/calibration.c
+++ b/liboptv/src/calibration.c
@@ -22,8 +22,8 @@
 *   char *add_file - path of file to contain added (distortions) parameters.
 */
 
-int write_ori (Exterior Ex, Interior I, Glass G, ap_52 ap, \
-        char *filename, char *add_file){
+int write_ori (Exterior Ex, Interior I, Glass G, ap_52 ap, char *filename, \
+char *add_file){
   FILE	*fp;
   int  	i, success = 0;
 
@@ -41,6 +41,7 @@ int write_ori (Exterior Ex, Interior I, Glass G, ap_52 ap, \
   fprintf (fp,"\n    %20.15f %20.15f  %20.15f\n", G.vec_x, G.vec_y, G.vec_z);
   fclose (fp);
   
+
   if (add_file == NULL) goto finalize;
   fp = fopen (add_file, "w");
   if (! fp) {
@@ -248,7 +249,9 @@ Calibration *read_calibration(char *ori_file, char *add_file,
     if (read_ori(&(ret->ext_par), &(ret->int_par), &(ret->glass_par), ori_file,
         &(ret->added_par), add_file, fallback_file))
     {
+
         rotation_matrix(&(ret->ext_par));
+
         return ret;
     } else {
         free(ret);
@@ -265,7 +268,11 @@ Calibration *read_calibration(char *ori_file, char *add_file,
 *
 *  Returns:
 *   modified Exterior Ex
-*
+* 
+* Alex: for some reason the explanation by photogrammetric people
+* e.g. https://engineering.purdue.edu/~bethel/rot2.pdf
+* gives the transposed matrix: M = M_k * M_phi * M_omega
+* 
 */
  void rotation_matrix (Exterior *Ex) {
  
@@ -279,14 +286,14 @@ Calibration *read_calibration(char *ori_file, char *add_file,
     ck = cos(Ex->kappa);
     sk = sin(Ex->kappa);
 
-    Ex->dm[0][0] = cp * cp;
+    Ex->dm[0][0] = cp * ck;
     Ex->dm[0][1] = -cp * sk;
     Ex->dm[0][2] = sp;
     Ex->dm[1][0] = co * sk + so * sp * ck;
     Ex->dm[1][1] = co * ck - so * sp * sk;
     Ex->dm[1][2] = -so * cp;
     Ex->dm[2][0] = so * sk - co * sp * ck;
-    Ex->dm[2][1] = so * ck + co* sp * sk;
+    Ex->dm[2][1] = so * ck + co * sp * sk;
     Ex->dm[2][2] = co * cp;
 }
 

--- a/liboptv/src/lsqadj.c
+++ b/liboptv/src/lsqadj.c
@@ -1,0 +1,246 @@
+/* parts of code of adjlib.c from Horst Beyer, Hannes Kirndorfer */
+
+/* TODO: understand what ata means and why it's not used 
+* anymore, but ata_v2 is used in orientation.c 
+*/
+
+#include "lsqadj.h"
+
+void ata ( double *a, double *ata, int m, int n ) {
+ /* matrix a and resultmatrix ata = at a 
+		       a is m * n, ata is n * n  */
+
+  register int      i, j, k;
+  
+  for (i = 0; i < n; i++)
+    {
+      for (j = 0; j < n; j++)
+	{
+	  *(ata+i*n+j) = 0.0;
+	  for (k = 0; k < m; k++)
+	    *(ata+i*n+j) +=  *(a+k*n+i)  * *(a+k*n+j);
+	}
+    }
+}
+
+
+void ata_v2 (double *a, double *ata, int m, int n, int n_large ) {
+/* matrix a and resultmatrix ata = at a 
+		       a is m * n, ata is n * n  */
+
+  register int      i, j, k;
+  
+  for (i = 0; i < n; i++)
+    {
+      for (j = 0; j < n; j++)
+	{
+	  *(ata+i*n_large+j) = 0.0;
+	  for (k = 0; k < m; k++)
+	    *(ata+i*n_large+j) +=  *(a+k*n_large+i)  * *(a+k*n_large+j);
+	}
+    }
+}
+
+
+void atl (double *u, double *a, double *l, int m, int n) {
+
+/* matrix a , vector l and 
+			 resultvector u = at l ,  a(m,n)  */
+
+  int      i, k;
+  
+  for (i = 0; i < n; i++)
+    {
+      *(u + i) = 0.0;
+      for (k = 0; k < m; k++)
+	*(u + i) += *(a + k * n + i) * *(l + k);
+    }  
+} 
+
+
+
+void atl_v2 (double *u, double *a, double *l, int m, int n, int n_large) {
+/* matrix a , vector l and 
+			 resultvector u = at l ,  a(m,n)  */
+
+  int      i, k;
+  
+  for (i = 0; i < n; i++)
+    {
+      *(u + i) = 0.0;
+      for (k = 0; k < m; k++)
+	*(u + i) += *(a + k * n_large + i) * *(l + k);
+    }
+  
+}
+
+/* input matrix size n * n */
+/* number of observations */
+
+void matinv (double *a, int n) {
+  int      ipiv, irow, icol;
+  double   pivot;	/* pivot element = 1.0 / aii */
+  double	npivot;	/*	negative of pivot */
+  
+  
+  for (ipiv = 0; ipiv < n; ipiv++)
+    {
+      pivot = 1.0 / *(a + ipiv * n + ipiv);
+      npivot = - pivot;
+      for (irow = 0; irow < n; irow++)
+	{
+	  for (icol = 0; icol < n; icol++)
+	    {
+	      if (irow != ipiv && icol != ipiv)
+		{
+		  *(a + irow * n + icol) -= *(a + ipiv * n + icol) * 
+		    *(a + irow * n + ipiv) * pivot;
+		}
+	    }
+	}
+      for (icol = 0; icol < n; icol++)
+	{
+	  if (ipiv != icol) 
+	    *(a + ipiv * n + icol) *= npivot;
+	}
+      for (irow = 0; irow < n; irow++)
+	{
+	  if (ipiv != irow)
+	    *(a + irow * n + ipiv) *= pivot;
+	}
+      *(a + ipiv * n + ipiv) = pivot;
+    }
+}
+
+
+/* a is the input matrix size n * n */
+/* n is the number of observations */
+void matinv_v2 (double *a, int n, int n_large) {
+  int      ipiv, irow, icol;
+  double   pivot;	/* pivot element = 1.0 / aii */
+  double	npivot;	/*	negative of pivot */
+  
+  
+  for (ipiv = 0; ipiv < n; ipiv++)
+    {
+      pivot = 1.0 / *(a + ipiv * n_large + ipiv);
+      npivot = - pivot;
+      for (irow = 0; irow < n; irow++)
+	{
+	  for (icol = 0; icol < n; icol++)
+	    {
+	      if (irow != ipiv && icol != ipiv)
+		{
+		  *(a + irow * n_large + icol) -= *(a + ipiv * n_large + icol) * 
+		    *(a + irow * n_large + ipiv) * pivot;
+		}
+	    }
+	}
+      for (icol = 0; icol < n; icol++)
+	{
+	  if (ipiv != icol) 
+	    *(a + ipiv * n_large + icol) *= npivot;
+	}
+      for (irow = 0; irow < n; irow++)
+	{
+	  if (ipiv != irow)
+	    *(a + irow * n_large + ipiv) *= pivot;
+	}
+      *(a + ipiv * n_large + ipiv) = pivot;
+    }
+}	/* end matinv */
+
+
+void matmul (double *a, double *b, double *c, int m, int n, int k) {  
+
+int    i,j,l;
+double  x,*pa,*pb,*pc;
+
+for (i=0; i<k; i++)
+  {  pb = b;
+  pa = a++;
+  for (j=0; j<m; j++)
+    {  pc = c;
+    x = 0.0;
+    for (l=0; l<n; l++)
+      {  x = x + *pb++ * *pc;
+      pc += k;
+      }
+    *pa = x;
+    pa += k;
+    }
+  c++;
+  }
+}
+
+
+
+void matmul_v2 (double *a, double *b, double *c, int m,int n,int k,\
+int m_large, int n_large) { 
+
+int    i,j,l;
+double  x,*pa,*pb,*pc;
+
+for (i=0; i<k; i++) {  
+  pb = b;
+  pa = a++;
+  for (j=0; j<m; j++) {  
+    pc = c;
+    x = 0.0;
+    for (l=0; l<n; l++) {  
+      x = x + *pb++ * *pc;
+      pc += k;
+      }
+	for (l=0;l<n_large-n;l++) {
+	  pb++;
+	  pc += k;
+	  }
+    *pa = x;
+    pa += k;
+    }
+  for (j=0;j<m_large-m;j++) {
+    pa += k;
+    }
+  c++;
+  }
+}
+
+
+void transp (double a[], int m, int n) {  
+  double  *b,*c,*d,*e;
+  int    i,j;
+  
+  b = (double*) malloc (m*n*sizeof(double));
+  if (b == 0) goto err;
+  d = a;
+  e = b;
+  
+  for (i=0; i<m; i++)
+    {  c = b++;
+    for (j=0; j<n; j++)
+      {  *c = *a++;
+      c += m;
+      }
+    }
+  
+  for (i=0; i<m*n; i++)
+    *d++ = *e++;
+  /*
+    free (b);
+    */   
+  return;
+  
+err:
+  printf ("\n\n ***   no memory space in C-subroutine transp   ***");
+  printf ("\n\n");
+  exit (-1);
+}
+
+void mat_transpose (double *mat1, double *mat2, int m, int n) {
+  int		i, j;
+  for (i=0; i<m; i++){ 
+  	for (j=0; j<n; j++){
+  		*(mat2+j*m+i) = *(mat1+i*n+j);
+  	}
+  }
+}

--- a/liboptv/src/main_test.c
+++ b/liboptv/src/main_test.c
@@ -1,0 +1,48 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "ray_tracing.h"
+#include "lsqadj.h"
+#include "math.h"
+#include "calibration.h"
+
+/* run as
+gcc main_test.c ray_tracing.c lsqadj.c -o main_test -I ../include/
+*/
+
+int main()
+{
+	double a[] = {1.0,1.0,1.0};
+	double b[] = {2.0,2.0,2.0};
+	double n[3];
+	
+	
+	Exterior test_ext = {
+        0.0, 0.0, 100.0,
+        0.0, 0.0, 0.0, 
+        {{1.0, 0.2, -0.3}, 
+        {0.2, 1.0, 0.0},
+        {-0.3, 0.0, 1.0}}};
+	
+	norm_cross(a,b,&n[0],&n[1],&n[2]);
+		
+    printf("\nHello World\n");
+    printf("Printing the result of norm_cross\n");
+    printf("%6.3f %6.3f %6.3f x %6.3f %6.3f %6.3f\n", a[0],a[1],a[2],b[0],b[1],b[2]);
+    printf("%6.3f %6.3f %6.3f\n", n[0],n[1],n[2]);
+    
+    printf("Matmul test:\n");
+    b[0] = 0.0;
+    b[1] = 0.0;
+    b[2] = 0.0;
+    
+    printf("a: %6.3f %6.3f %6.3f\n", a[0],a[1],a[2]);
+    printf("b: %6.3f %6.3f %6.3f\n", b[0],b[1],b[2]);
+    
+    matmul (b, (double *) test_ext.dm, a, 3,3,1);
+    
+    printf("a: %6.3f %6.3f %6.3f\n", a[0],a[1],a[2]);
+    printf("b: %6.3f %6.3f %6.3f\n", b[0],b[1],b[2]);
+    
+    
+    
+}

--- a/liboptv/src/ray_tracing.c
+++ b/liboptv/src/ray_tracing.c
@@ -1,0 +1,216 @@
+/****************************************************************************
+
+Routine:				ray_tracing
+
+Author/Copyright:		Hans-Gerd Maas
+
+Address:		       	Institute of Geodesy and Photogrammetry
+			       		ETH - Hoenggerberg
+			       		CH - 8093 Zurich
+
+Creation Date:			21.4.88
+Modification date: 		August 4, 2013, Alex Liberzon
+						ray_tracing_v2 is the only functions used
+						
+	
+Description:	       	traces one ray, given by image coordinates,
+			       	exterior and interior orientation 
+			       	through dufferent media
+			       	(see Hoehle, Manual of photogrammetry)
+	
+Routines contained:		-
+
+****************************************************************************/
+
+
+#include "ray_tracing.h"
+
+
+
+/* removed point_line_line from ray_tracing - it is never used here */
+
+/* Normalized cross product of two vectors
+*
+* Arguments:
+*	double a[3], double b[3] - two vectors of 3 x 1 
+* Returns:
+* 	double *n1, *n2, *n3 - three components of the cross product vector. 
+*  Note: the vector is normalized to unity length
+*
+* TODO: replace by standard vec_utils subroutines 
+*/
+
+void norm_cross(double a[3], double b[3], double *n1, double *n2, double *n3) {
+
+//Beat Lüthi Nov 2008
+
+	double  res[3], dummy, norm;
+
+	res[0]=a[1]*b[2]-a[2]*b[1];
+	res[1]=a[2]*b[0]-a[0]*b[2];
+	res[2]=a[0]*b[1]-a[1]*b[0];
+	
+	// norm = sqrt( (res[0]*res[0]) + (res[1]*res[1]) + (res[2]*res[2]) );
+	
+	// printf("Res: %6.3f %6.3f %6.3f\n", res[0],res[1],res[2]);
+	
+	modu(res,&norm);
+	
+	// printf(" Norm : %6.3f \n",norm);
+	
+	// fixing the zero length norm bug:
+	// Alex, Aug 3, 2013
+	// Thanks for the test suite :)
+	
+	if (norm == 0.0){
+		*n1 = res[0];
+		*n2 = res[0];
+		*n3 = res[0];
+	} else {	
+	*n1=res[0]/norm;
+	*n2=res[1]/norm;
+	*n3=res[2]/norm;
+	}
+}
+
+/* Beat Lüthi Nov 2008
+* Dot product of two vectors 
+* TODO: use ready subroutines from vec_utils.h
+*
+*/
+
+void dot(double a[3], double b[3], double *d) {
+
+	*d = a[0]*b[0] + a[1]*b[1] + a[2]*b[2];
+}
+
+
+/* Modulus of a vector
+* TODO: use ready subroutine called norm in vec_utils.h
+*/
+//Beat Lüthi Nov 2008
+void modu(double a[3], double *m) {
+
+	*m = sqrt(a[0]*a[0] + a[1]*a[1] + a[2]*a[2]);
+}
+
+
+/* ray_tracing_v2 
+*
+*
+* 
+*/
+
+
+void ray_tracing_v2 (double x, double y, Exterior Ex, Interior I, Glass G, mm_np mm,\
+double *Xb2, double *Yb2, double *Zb2, double *a3, double *b3, double *c3) {
+/* ray-tracing, see HOEHLE and Manual of Photogrammetry */
+
+	double  a1, b1, c1, a2, b2, c2, Xb1, Yb1, Zb1, d1, d2, cosi1, cosi2,
+			vect1[3], vect2[3], factor, s2;
+
+	double a[3],b[3],base2[3],c,dummy,bn[3],bp[3],n,p;
+
+	s2 = sqrt (x*x + y*y + I.cc*I.cc);
+	
+	/* direction cosines in image coordinate system */
+	vect1[0] = x/s2;  vect1[1] = y/s2;	vect1[2] = -I.cc/s2;
+
+	matmul (vect2, (double *) Ex.dm, vect1, 3,3,1);
+ 	
+	/* direction cosines in space coordinate system , medium n1 */
+	a1 = vect2[0];  b1 = vect2[1];  c1 = vect2[2];  
+	
+    //old d1 = -(Ex.z0 - mm.d[0]) / c1;
+    //find dist to outer interface
+	//...   from Jakob Mann vector3 XLinePlane(vector3 a, vector3 b, struct plane pl)
+    //...   a + b*((pl.c - dot(pl.base[2],a))/dot(pl.base[2],b));
+    
+	/*Ex.x0=0.;
+    Ex.y0=20.;
+    Ex.z0=10.;
+    Ex.omega=-0.7853981;
+    Ex.phi=0.;
+    Ex.kappa=0.;
+    G.vec_x=0.;
+    G.vec_y=10.;
+    G.vec_z=0.;
+	vect2[0]=0.;
+	vect2[1]=-1./sqrt(2.);
+	vect2[2]=-1./sqrt(2.);*/
+   
+	
+	a[0] = Ex.x0; a[1] = Ex.y0; a[2] = Ex.z0;
+	b[0] = vect2[0]; b[1] = vect2[1]; b[2] = vect2[2];
+	c = sqrt(G.vec_x*G.vec_x + G.vec_y*G.vec_y + G.vec_z*G.vec_z);
+	base2[0] = G.vec_x/c; base2[1] = G.vec_y/c; base2[2] = G.vec_z/c;
+
+	c = c + mm.d[0];
+	dummy = base2[0]*a[0]+base2[1]*a[1]+base2[2]*a[2];
+	dummy = dummy-c;
+	d1 = -dummy/(base2[0]*b[0]+base2[1]*b[1]+base2[2]*b[2]);
+	
+
+	/* point on the horizontal plane between n1,n2 */
+	//old Xb1 = Ex.x0 + d1*a1;  Yb1 = Ex.y0 + d1*b1;  Zb1 = Ex.z0 + d1*c1;
+	Xb1 = a[0] + b[0]*d1;
+	Yb1 = a[1] + b[1]*d1;
+	Zb1 = a[2] + b[2]*d1;
+	
+	//old cosi1 = c1;
+	//cosi1=base2[0]*b[0]+base2[1]*b[1]+base2[2]*b[2];
+	//factor = cosi1 * mm.n1/mm.n2[0]
+	//	   + sqrt (1 - (mm.n1*mm.n1)/(mm.n2[0]*mm.n2[0])
+	//	   			 + (cosi1*cosi1)*(mm.n1*mm.n1)/(mm.n2[0]*mm.n2[0]));
+
+	/* direction cosines in space coordinate system , medium n2 */
+	//old a2 = a1 * mm.n1/mm.n2[0];
+	//old b2 = b1 * mm.n1/mm.n2[0];
+	//old c2 = c1 * mm.n1/mm.n2[0] - factor;
+	
+	//old d2 = -mm.d[0]/c2;
+
+    bn[0] = base2[0]; bn[1] = base2[1]; bn[2] = base2[2];
+	n = (b[0]*bn[0]+b[1]*bn[1]+b[2]*bn[2]);
+	bp[0] = b[0] - bn[0]*n; bp[1] = b[1] - bn[1]*n; bp[2] = b[2] - bn[2]*n;
+	dummy = sqrt(bp[0]*bp[0] + bp[1]*bp[1] + bp[2]*bp[2]);
+	bp[0] = bp[0]/dummy;bp[1]=bp[1]/dummy;bp[2]=bp[2]/dummy;
+
+	p = sqrt(1 - n*n);
+	p = p * mm.n1/mm.n2[0];//interface parallel
+	//n = n * mm.n1/mm.n2[0] - factor;//interface normal
+	n =-sqrt(1-p*p);
+	a2 = p*bp[0]+n*bn[0];
+	b2 = p*bp[1]+n*bn[1];
+	c2 = p*bp[2]+n*bn[2];
+    d2 = mm.d[0]/fabs((base2[0]*a2+base2[1]*b2+base2[2]*c2));
+	
+
+	/* point on the horizontal plane between n2,n3 */
+	*Xb2 = Xb1 + d2*a2;  *Yb2 = Yb1 + d2*b2;  *Zb2 = Zb1 + d2*c2;
+	
+	//old cosi2 = c2;
+	//cosi2=base2[0]*a2+base2[1]*b2+base2[2]*c2;
+	//factor = cosi2 * mm.n2[0]/mm.n3 
+	//	   + sqrt (1 - (mm.n2[0]*mm.n2[0])/(mm.n3*mm.n3)
+	//	   			 + (cosi2*cosi2)*(mm.n2[0]*mm.n2[0])/(mm.n3*mm.n3));
+
+	/* direction cosines in space coordinate system , medium mm.n3 */
+	//old *a3 = a2 * mm.n2[0]/mm.n3;
+	//old *b3 = b2 * mm.n2[0]/mm.n3;
+	//old *c3 = c2 * mm.n2[0]/mm.n3 - factor;
+
+	n=(a2*bn[0]+b2*bn[1]+c2*bn[2]);
+	bp[0]=a2-bn[0]*n;bp[1]=b2-bn[1]*n;bp[2]=c2-bn[2]*n;
+	dummy=sqrt(bp[0]*bp[0]+bp[1]*bp[1]+bp[2]*bp[2]);
+	bp[0]=bp[0]/dummy;bp[1]=bp[1]/dummy;bp[2]=bp[2]/dummy;
+
+	p=sqrt(1-n*n);
+	p = p * mm.n2[0]/mm.n3;//interface parallel
+	//n = n * mm.n2[0]/mm.n3 - factor;//interface normal
+	n = -sqrt(1-p*p);
+	*a3=p*bp[0]+n*bn[0];
+	*b3=p*bp[1]+n*bn[1];
+	*c3=p*bp[2]+n*bn[2];
+}
+

--- a/liboptv/tests/CMakeLists.txt
+++ b/liboptv/tests/CMakeLists.txt
@@ -5,11 +5,12 @@ include_directories(. ../src ../include/)
 
 add_executable(check_fb check_fb.c)
 add_dependencies(check_fb optv)
-
 add_executable(check_calibration check_calibration.c)
 add_dependencies(check_calibration optv)
 add_executable(check_parameters check_parameters.c)
 add_dependencies(check_parameters optv)
+add_executable(check_ray_tracing check_ray_tracing.c)
+add_dependencies(check_ray_tracing optv)
 
 get_property(OPTV_LIBRARY TARGET optv PROPERTY LOCATION)
 set(LIBS ${LIBS} ${CHECK_LIBRARIES} ${OPTV_LIBRARY})
@@ -21,6 +22,13 @@ add_custom_command(TARGET check_fb PRE_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory
     ${CMAKE_CURRENT_SOURCE_DIR}/testing_fodder $<TARGET_FILE_DIR:check_fb>/testing_fodder)
 
+target_link_libraries(check_parameters ${LIBS})
+add_test(check_parameters ${CMAKE_CURRENT_BINARY_DIR}/check_parameters)
+
+add_custom_command(TARGET check_parameters PRE_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+    ${CMAKE_CURRENT_SOURCE_DIR}/testing_fodder $<TARGET_FILE_DIR:check_parameters>/testing_fodder)
+
 target_link_libraries(check_calibration ${LIBS})
 add_test(check_calibration ${CMAKE_CURRENT_BINARY_DIR}/check_calibration)
 
@@ -28,9 +36,10 @@ add_custom_command(TARGET check_calibration PRE_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory
     ${CMAKE_CURRENT_SOURCE_DIR}/testing_fodder $<TARGET_FILE_DIR:check_calibration>/testing_fodder)
 
-target_link_libraries(check_parameters ${LIBS})
-add_test(check_parameters ${CMAKE_CURRENT_BINARY_DIR}/check_parameters)
+        
+target_link_libraries(check_ray_tracing ${LIBS})
+add_test(check_ray_tracing ${CMAKE_CURRENT_BINARY_DIR}/check_ray_tracing)
 
-add_custom_command(TARGET check_parameters PRE_BUILD
+add_custom_command(TARGET check_ray_tracing PRE_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${CMAKE_CURRENT_SOURCE_DIR}/testing_fodder $<TARGET_FILE_DIR:check_parameters>/testing_fodder)
+    ${CMAKE_CURRENT_SOURCE_DIR}/testing_fodder $<TARGET_FILE_DIR:check_ray_tracing>/testing_fodder)

--- a/liboptv/tests/check_calibration.c
+++ b/liboptv/tests/check_calibration.c
@@ -26,6 +26,7 @@ Calibration test_cal(void) {
     ap_52 correct_addp = {0., 0., 0., 0., 0., 1., 0.};
     Calibration correct_cal = {correct_ext, correct_int, correct_glass, 
         correct_addp};
+
     rotation_matrix(&correct_cal.ext_par);
     
     return correct_cal;

--- a/liboptv/tests/check_ray_tracing.c
+++ b/liboptv/tests/check_ray_tracing.c
@@ -1,0 +1,290 @@
+/* Unit tests for ray tracing. */
+
+#include <check.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include "parameters.h"
+#include "calibration.h"
+#include "ray_tracing.h"
+
+#define EPS 1E-5
+
+
+START_TEST(test_norm_cross)
+{
+
+double n[3];
+
+// test simple cross-product normalized to unity
+
+double a[] = {1.0, 0.0, 0.0};
+double b[] = {0.0, 2.0, 0.0};
+
+norm_cross(a,b,&n[0],&n[1],&n[2]);
+fail_unless( (n[0] == 0.0) && (n[1] == 0.0) && (n[2] == 1.0));
+
+
+// test negative values in the output
+
+norm_cross(b,a,&n[0],&n[1],&n[2]);
+// fail_unless( (n[0] == 0.0) && (n[1] == 0.0) && (n[2] == -1.0));
+
+
+ck_assert_msg( fabs(n[0] - 0.0) < EPS && 
+     		   fabs(n[1] - 0.0) < EPS && 
+     		   fabs(n[2] - -1.0)  < EPS,
+         "Was expecting n to be 0., 0., -1. but found %f %f %f\n", n[0],n[1],n[2]);
+         
+
+// our norm_cross had a bug when multiplying the parallel vectors
+// it was returning nan instead of 0.0
+// fixed Aug. 3, 2013, see in ray_tracing.c
+
+norm_cross(a,a,&n[0],&n[1],&n[2]);
+// fail_unless( (n[0] == 0.0) && (n[1] == 0.0) && (n[2] == 0.0));
+
+ck_assert_msg( fabs(n[0] - 0.0) < EPS && 
+     		   fabs(n[1] - 0.0) < EPS && 
+     		   fabs(n[2] - 0.0)  < EPS,
+         "Was expecting n to be 0., 0., 0. but found %f %f %f\n", n[0],n[1],n[2]);
+
+
+}
+END_TEST
+
+
+START_TEST(test_dot)
+{
+
+double d;
+
+// test simple cross-product normalized to unity
+
+double a[] = {1.0, 0.0, 0.0};
+double b[] = {0.0, 2.0, 0.0};
+
+dot(a,b,&d);
+
+//fail_unless( d == 0.0 );
+ck_assert_msg( fabs(d - 0.0) < EPS,
+         "Was expecting d to be 0.0 but found %f \n", d);
+
+b[0] = 2.0;
+b[1] = 2.0;
+b[2] = 0.0;
+
+dot(b,a,&d);
+// fail_unless( d == 2.0 );
+ck_assert_msg( fabs(d - 2.0) < EPS,
+         "Was expecting d to be 2.0 but found %f \n", d);
+
+}
+END_TEST
+
+
+START_TEST(test_modu)
+{
+double a[]= {10.0, 0.0, 0.0};
+double m;
+
+modu(a,&m);
+
+// fail_unless( m == 10.0);
+ck_assert_msg( fabs(m - 10.0) < EPS,
+         "Was expecting m to be 10.0 but found %f \n", m);
+
+}
+END_TEST
+
+
+START_TEST(test_matmul)
+{
+
+	double a[] = {1.0,1.0,1.0};
+	double b[] = {0.0,0.0,0.0};
+		
+	Exterior test_Ex = {
+        0.0, 0.0, 100.0,
+        0.0, 0.0, 0.0, 
+        {{1.0, 0.2, -0.3}, 
+        {0.2, 1.0, 0.0},
+        {-0.3, 0.0, 1.0}}};
+        
+    // printf("a: %6.3f %6.3f %6.3f\n", a[0],a[1],a[2]);
+    // printf("b: %6.3f %6.3f %6.3f\n", b[0],b[1],b[2]);
+    
+    
+    matmul (b, (double *) test_Ex.dm, a, 3,3,1);
+    
+    // printf("a: %6.3f %6.3f %6.3f\n", a[0],a[1],a[2]);
+    // printf("b: %6.3f %6.3f %6.3f\n", b[0],b[1],b[2]);
+    
+    
+     ck_assert_msg( fabs(b[0] - 0.9) < EPS && 
+     				fabs(b[1] - 1.20) < EPS && 
+     			    fabs(b[2] - 0.700)  < EPS,
+         "Was expecting b to be 0.9,1.2,0.7 but found %f %f %f\n", b[0],b[1],b[2]);
+    
+}
+END_TEST
+
+
+
+START_TEST(test_ray_tracing)
+{
+	double     x1, y1, a,b,c, X1,Y1,Z1;
+	
+	x1 = 100.;
+	y1 = 100.;
+	
+
+		
+	Exterior test_Ex = {
+        0.0, 0.0, 100.0,
+        0.0, 0.0, 0.0, 
+        {{1.0, 0.2, -0.3}, 
+        {0.2, 1.0, 0.0},
+        {-0.3, 0.0, 1.0}}};
+        
+    Interior test_I = {0., 0., 100.};
+    Glass test_G = {0.0001, 0.00001, 1.};
+    // ap_52 test_addp = {0., 0., 0., 0., 0., 1., 0.};
+    
+/*    
+    typedef struct {
+    int  	nlay; 
+    double  n1;
+    double  n2[3];
+    double  d[3];
+    double  n3;
+    int     lut;
+} mm_np;
+ */   
+    
+    mm_np test_mmp = {
+    3,
+    1.,
+    {1.49,0.,0.},
+    {5.,0.,0.},
+    1.33,
+    1.};   
+            
+    ray_tracing_v2 (x1,y1, test_Ex, test_I, test_G, test_mmp, \
+    					&X1, &Y1, &Z1, &a, &b, &c);
+    
+    ck_assert_msg( fabs(X1 - 110.406944) < EPS && 
+     			   fabs(Y1 - 88.325788) < EPS && 
+     			   fabs(Z1 - 0.988076)  < EPS,
+         "Was expecting X1,Y1,Z1 to be 110.407 88.326 0.988 but found %f %f %f\n", \
+         		X1,Y1,Z1);
+    ck_assert_msg( fabs(a - 0.387960) < EPS && 
+     			   fabs(b - 0.310405) < EPS && 
+     			   fabs(c - -0.867834)  < EPS,
+         "Was expecting a,b,c to be 0.387960 0.310405 -0.867834 but found %f %f %f\n", \
+         a,b,c);          
+    
+    
+    
+}
+END_TEST
+
+
+START_TEST(test_rotation_matrix)
+{
+
+/*
+    Exterior Ex_correct, Ex; 
+    
+    Ex_correct.x0 = 0.0;
+    Ex_correct.y0 = 0.0;
+    Ex_correct.z0 = 0.0;
+    Ex_correct.omega = 0.0;
+    Ex_correct.phi = 0.0;
+    Ex_correct.kappa = 0.0;
+    Ex_correct.dm[0][0] = 1.0;
+    Ex_correct.dm[0][1] = 0.0;
+    Ex_correct.dm[0][2] = 0.0;
+    Ex_correct.dm[1][0] = 0.0;
+    Ex_correct.dm[1][1] = 1.0;
+    Ex_correct.dm[1][2] = 0.0;
+    Ex_correct.dm[2][0] = 0.0;
+    Ex_correct.dm[2][1] = 0.0;
+    Ex_correct.dm[2][2] = 1.0;
+    
+	Ex.x0 = 0.0;
+    Ex.y0 = 0.0;
+    Ex.z0 = 0.0;
+    Ex.omega = 0.0;
+    Ex.phi = 0.0;
+    Ex.kappa = 0.0;
+*/
+    /*
+    Ex.dm[0][0] = 0.0;
+    Ex.dm[0][1] = 0.0;
+    Ex.dm[0][2] = 0.0;
+    Ex.dm[1][0] = 0.0;
+    Ex.dm[1][1] = 0.0;
+    Ex.dm[1][2] = 0.0;
+    Ex.dm[2][0] = 0.0;
+    Ex.dm[2][1] = 0.0;
+    Ex.dm[2][2] = 0.0;
+    */
+    
+//    rotation_matrix(&Ex);
+    
+    /* 
+    printf("%s\n", "Exterior:");
+    printf("%lf\n",Ex.x0);
+    printf("%lf\n",Ex.y0);
+    printf("%lf\n",Ex.z0);
+    printf("%lf\n",Ex.omega);
+    printf("%lf\n",Ex.phi);
+    printf("%lf\n",Ex.kappa);
+    printf("%lf\n",Ex.dm[0][0]);
+    printf("%lf\n",Ex.dm[0][1]);
+    printf("%lf\n",Ex.dm[0][2]);
+    printf("%lf\n",Ex.dm[1][0]);
+    printf("%lf\n",Ex.dm[1][1]);
+    printf("%lf\n",Ex.dm[1][2]);
+    printf("%lf\n",Ex.dm[2][0]);
+    printf("%lf\n",Ex.dm[2][1]);
+    printf("%lf\n",Ex.dm[2][2]);
+    */
+    
+    fail_unless(1 == 1);
+    
+   //  fail_unless(compare_exterior(&Ex, &Ex_correct));    
+    
+}
+END_TEST
+
+
+
+
+Suite* fb_suite(void) {
+    Suite *s = suite_create ("Ray tracing");
+ 
+    TCase *tc = tcase_create ("ray tracing test");
+    tcase_add_test(tc, test_norm_cross);
+    tcase_add_test(tc, test_dot);
+    tcase_add_test(tc, test_dot);
+    tcase_add_test(tc, test_matmul);
+    tcase_add_test(tc, test_ray_tracing);
+    tcase_add_test(tc, test_rotation_matrix);
+    suite_add_tcase (s, tc);   
+    return s;
+}
+
+int main(void) {
+    int number_failed;
+    Suite *s = fb_suite ();
+    SRunner *sr = srunner_create (s);
+    //srunner_run_all (sr, CK_ENV);
+    //srunner_run_all (sr, CK_SUBUNIT);
+    srunner_run_all (sr, CK_VERBOSE);
+    number_failed = srunner_ntests_failed (sr);
+    srunner_free (sr);
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+


### PR DESCRIPTION
ray_tracing is one of the core functions used by many higher order functions such as epi_to_mm, etc. This function takes the Exterior, Interior, Glass and multi-media parameters, the point of incidence of the vector on the air-side of glass and returns the position of the vector on the water side and the angles of the vector looking into the water side.

I created the unit-test suite for all the used subfunctions:

norm_cross
dot
matmul
ray_tracing

there are few important things to note in this submission:

the tests are a bit complex, allowing for floating values comparison within a predefined tolerance (1E-5 at the moment)

fail_unless is apparently appreciated by the Check (current version used on Mac OS X is 2.8.10) so we changed the tests to use 
ck_assert_msg( ) function which is much more informative and helpful if we use:

make
make test 
ctest -VV

ctest -VV is the most verbosed run of the check unit test suite, printing each of the failed messages. Use this template for other, more complicated tests.
