### PR TITLE
Introduce 'make check' target.

### DIFF
--- a/liboptv/README
+++ b/liboptv/README
@@ -42,7 +42,7 @@ CMake. Before installation first we need to make sure that the dependencies are 
    
      $ cmake
      $ make
-     $ make check # optional, runs the test suite.
+     $ make verify # optional, runs the test suite.
      $ make install
 
 The install process will put the header files and libraries in default system
@@ -128,7 +128,7 @@ if it is a different path in your system.
 Now to build and install liboptv, type
 
     $ make
-    $ make check
+    $ make verify
     $ make install
 
 This would install liboptv in what MSYS refers to as /usr, which is 

--- a/liboptv/tests/CMakeLists.txt
+++ b/liboptv/tests/CMakeLists.txt
@@ -41,6 +41,6 @@ add_custom_command(TARGET check_parameters PRE_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory
     ${CMAKE_CURRENT_SOURCE_DIR}/testing_fodder $<TARGET_FILE_DIR:check_parameters>/testing_fodder)
 
-add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
-add_dependencies(check check_fb check_calibration check_parameters)
+add_custom_target(verify COMMAND ${CMAKE_CTEST_COMMAND})
+add_dependencies(verify check_fb check_calibration check_parameters)
 


### PR DESCRIPTION
This is an updated version of a previous pull request that will be closed presently. It mostly just brings it up to date with the current master of OpenPTV.

The feature is to stop building the 'check' executables on every make, and only build them on 'make check' invocation.
