### PR TITLE
Vec utils

### DIFF
--- a/liboptv/include/lsqadj.h
+++ b/liboptv/include/lsqadj.h
@@ -8,9 +8,6 @@ void atl(double *u, double *a, double *l, int m, int n, int n_large);
 void matinv (double *a, int n, int n_large);
 void matmul(double *a, double *b, double *c, int m,int n,int k,\
 int m_large, int n_large);
-void modu(double a[3], double *m);
 void norm_cross(double a[3], double b[3], double n[3]);
-void dot(double a[3], double b[3], double *d);
-
 
 #endif

--- a/liboptv/include/vec_utils.h
+++ b/liboptv/include/vec_utils.h
@@ -1,0 +1,26 @@
+/* Utilities for handling simple 3d vectors implemented as an array of 3
+doubles.
+*/
+
+#ifndef VEC_UTILS_H
+#define VEC_UTILS_H
+
+#include <math.h>
+
+# define EMPTY_CELL 0.0/0.0
+# define norm(x,y,z) sqrt((x)*(x) + (y)*(y) + (z)*(z))
+
+typedef double vec3d[3];
+
+void vec_init(vec3d init);
+void vec_copy(vec3d dest, vec3d src);
+void vec_subt(vec3d from, vec3d sub, vec3d output);
+void vec_scalar_mul(vec3d vec, double scalar, vec3d output);
+double vec_norm(vec3d vec);
+double vec_diff_norm(vec3d vec1, vec3d vec2);
+double vec_dot(vec3d vec1, vec3d vec2);
+int vec_cmp(vec3d vec1, vec3d vec2);
+int vec_iapprox_cmp(vec3d vec1, vec3d vec2, double eps);
+
+#endif
+

--- a/liboptv/include/vec_utils.h
+++ b/liboptv/include/vec_utils.h
@@ -22,7 +22,7 @@ double vec_norm(vec3d vec);
 double vec_diff_norm(vec3d vec1, vec3d vec2);
 double vec_dot(vec3d vec1, vec3d vec2);
 int vec_cmp(vec3d vec1, vec3d vec2);
-int vec_iapprox_cmp(vec3d vec1, vec3d vec2, double eps);
+int vec_approx_cmp(vec3d vec1, vec3d vec2, double eps);
 
 #endif
 

--- a/liboptv/include/vec_utils.h
+++ b/liboptv/include/vec_utils.h
@@ -7,12 +7,14 @@ doubles.
 
 #include <math.h>
 
-# define EMPTY_CELL 0.0/0.0
-# define norm(x,y,z) sqrt((x)*(x) + (y)*(y) + (z)*(z))
+#define EMPTY_CELL 0.0/0.0
+#define is_empty(x) isnan(x)
+#define norm(x,y,z) sqrt((x)*(x) + (y)*(y) + (z)*(z))
 
 typedef double vec3d[3];
 
 void vec_init(vec3d init);
+void vec_set(vec3d dest, double x, double y, double z);
 void vec_copy(vec3d dest, vec3d src);
 void vec_subt(vec3d from, vec3d sub, vec3d output);
 void vec_scalar_mul(vec3d vec, double scalar, vec3d output);

--- a/liboptv/src/CMakeLists.txt
+++ b/liboptv/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 include_directories("../include/")
-add_library (optv SHARED tracking_frame_buf.c calibration.c parameters.c lsqadj.c ray_tracing.c trafo.c)
+add_library (optv SHARED tracking_frame_buf.c calibration.c parameters.c lsqadj.c ray_tracing.c trafo.c vec_utils.c)
 
 
 if(UNIX)

--- a/liboptv/src/lsqadj.c
+++ b/liboptv/src/lsqadj.c
@@ -1,4 +1,6 @@
 #include "lsqadj.h"
+#include "vec_utils.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -163,43 +165,22 @@ for (i=0; i<k; i++) {
 
 void norm_cross(double a[3], double b[3], double n[3]) {
 
-    double  res[3], dummy, norm;
+    double dummy, rnorm;
+    vec3d res;
 
     res[0]=a[1]*b[2]-a[2]*b[1];
     res[1]=a[2]*b[0]-a[0]*b[2];
     res[2]=a[0]*b[1]-a[1]*b[0];
     
-    modu(res,&norm);
+    rnorm = vec_norm(res);
     
-    
-    if (norm == 0.0){ // avoids zero length vector bug
+    if (rnorm == 0.0){ // avoids zero length vector bug
         n[0] = res[0];
         n[1] = res[0];
         n[2] = res[0];
     } else {    
-    n[0]=res[0]/norm;
-    n[1]=res[1]/norm;
-    n[2]=res[2]/norm;
+    n[0]=res[0]/rnorm;
+    n[1]=res[1]/rnorm;
+    n[2]=res[2]/rnorm;
     }
 }
-
-/* Dot product of two vectors 
-* TODO: use ready subroutines from vec_utils.h
-*
-*/
-
-void dot(double a[3], double b[3], double *d) {
-
-    *d = a[0]*b[0] + a[1]*b[1] + a[2]*b[2];
-}
-
-
-/* Modulus of a vector
-* TODO: use ready subroutine called norm in vec_utils.h
-*/
-void modu(double a[3], double *m) {
-
-    *m = sqrt(a[0]*a[0] + a[1]*a[1] + a[2]*a[2]);
-}
-
-

--- a/liboptv/src/vec_utils.c
+++ b/liboptv/src/vec_utils.c
@@ -1,0 +1,141 @@
+/* implemnentation of vec_utils.h 
+
+Implementation detail: yes, we use loops. In this day and age, compilers
+can optimize this away at the cost of code size, so it is up to the build 
+system to decide whether to invest in loop peeling etc. Here we write
+the logical structure, and allow optimizing for size as well.
+*/
+
+#include "vec_utils.h"
+#include <math.h>
+
+/*  vec_init() initializes all components of a 3D vector to NaN.
+    
+    Arguments:
+    vec3d init - the vector to initialize
+*/
+void vec_init(vec3d init) {
+    int ix;
+    for (ix = 0; ix < 3; ix ++) init[ix] = EMPTY_CELL;
+}
+
+/*  vec_set() sets the components of a  3D vector from separate doubles.
+
+    Arguments:
+    vec3d dest - the destination of setting, the vector to overwrite.
+    double x, y, z - new components for the vector.
+*/
+void vec_set(vec3d dest, double x, double y, double z) {
+    dest[0] = x;
+    dest[1] = y;
+    dest[2] = z;
+}
+
+/*  vec_copy() copies one 3D vector into another.
+
+    Arguments:
+    vec3d dest - the destination of copy, the vector to overwrite.
+    vec3d src - the vector to copy.
+*/
+void vec_copy(vec3d dest, vec3d src) {
+    int ix;
+    for (ix = 0; ix < 3; ix ++) dest[ix] = src[ix];
+}
+
+/*  vec_subt() subtracts two 3D vectors.
+    
+    Arguments:
+    vec3d from, sub, output - result is output[i] = from[i] - sub[i]
+*/
+void vec_subt(vec3d from, vec3d sub, vec3d output) {
+    int ix;
+    for (ix = 0; ix < 3; ix ++) output[ix] = from[ix] - sub[ix];
+}
+
+/*  vec_scalar_mul() multiplies a vector by a scalar.
+    
+    Arguments:
+    vec3d vec - the vector multiplicand
+    double scalar - the scalar multiplier
+    vec3d output - result buffer.
+*/
+void vec_scalar_mul(vec3d vec, double scalar, vec3d output) {
+    int ix;
+    for (ix = 0; ix < 3; ix ++) output[ix] = scalar * vec[ix];
+}
+
+/* Implements the common operation of finding the norm of a difference between
+   two vectors. This happens a lot, so we have an optimized function.
+   
+   Arguments:
+   vec3d vec1, vec2 - we need the difference between these vectors.
+   
+   Returns:
+   double, the norm of the difference, i.e. ||vec1 - vec2||
+*/
+double vec_diff_norm(vec3d vec1, vec3d vec2) {
+    return norm(vec1[0] - vec2[0], vec1[1] - vec2[1], vec1[2] - vec2[2]);
+}
+
+/* vec_norm() calculates the norm of a vector.
+   
+   Arguments:
+   vec3d vec - the vector to norm.
+*/
+double vec_norm(vec3d vec) {
+    /* Just plug into the macro */
+    return norm(vec[0], vec[1], vec[2]);
+}
+
+/*  vec_dot() gives the dot product of two vectors. 
+    
+    Arguments:
+    vec3d vec1, vec2 - the vectors whose dot product is sought.
+    
+    Returns:
+    double, the dot of vec1 and vec2, i.e. <vec1, vec2>
+*/
+double vec_dot(vec3d vec1, vec3d vec2) {
+    int ix;
+    double sum = 0;
+    
+    for (ix = 0; ix < 3; ix ++) sum += vec1[ix]*vec2[ix];
+    return sum;
+}
+
+/*  vec_cmp() checks whether two vectors are equal.
+    
+    Arguments:
+    vec3d vec1, vec2 - the vectors to compare.
+    
+    Returns:
+    int - true if equal, 0 otherwise.
+*/
+int vec_cmp(vec3d vec1, vec3d vec2) {
+    int ix;
+    
+    for (ix = 0; ix < 3; ix ++) 
+        if (vec1[ix] != vec2[ix])
+            return 0;
+    return 1;
+}
+
+/*  vec_approx_cmp() checks whether two vectors are approximately equal.
+    
+    Arguments:
+    vec3d vec1, vec2 - the vectors to compare.
+    double eps - tolerance, the maximal difference between each two components
+        that still counts as equal (typ. 1e-10 or less).
+    
+    Returns:
+    int - true if equal, 0 otherwise.
+*/
+int vec_approx_cmp(vec3d vec1, vec3d vec2, double eps) {
+    int ix;
+    
+    for (ix = 0; ix < 3; ix ++) 
+        if (fabs(vec1[ix] - vec2[ix]) > eps)
+            return 0;
+    return 1;
+}
+

--- a/liboptv/tests/CMakeLists.txt
+++ b/liboptv/tests/CMakeLists.txt
@@ -21,6 +21,8 @@ add_dependencies(check_ray_tracing optv)
 add_executable(check_trafo EXCLUDE_FROM_ALL check_trafo.c)
 add_dependencies(check_trafo optv)
 
+add_executable(check_vec_utils EXCLUDE_FROM_ALL check_vec_utils.c)
+add_dependencies(check_vec_utils optv)
 
 get_property(OPTV_LIBRARY TARGET optv PROPERTY LOCATION)
 set(LIBS ${LIBS} ${CHECK_LIBRARIES} ${OPTV_LIBRARY})
@@ -36,6 +38,13 @@ add_test(check_fb ${CMAKE_CURRENT_BINARY_DIR}/check_fb)
 add_custom_command(TARGET check_fb PRE_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory
     ${CMAKE_CURRENT_SOURCE_DIR}/testing_fodder $<TARGET_FILE_DIR:check_fb>/testing_fodder)
+
+target_link_libraries(check_vec_utils ${LIBS})
+add_test(check_vec_utils ${CMAKE_CURRENT_BINARY_DIR}/check_vec_utils)
+
+add_custom_command(TARGET check_vec_utils PRE_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+    ${CMAKE_CURRENT_SOURCE_DIR}/testing_fodder $<TARGET_FILE_DIR:check_vec_utils>/testing_fodder)
 
 target_link_libraries(check_calibration ${LIBS})
 add_test(check_calibration ${CMAKE_CURRENT_BINARY_DIR}/check_calibration)
@@ -75,5 +84,5 @@ add_custom_command(TARGET check_trafo PRE_BUILD
     ${CMAKE_CURRENT_SOURCE_DIR}/testing_fodder $<TARGET_FILE_DIR:check_trafo>/testing_fodder)    
 
 add_custom_target(verify COMMAND ${CMAKE_CTEST_COMMAND})
-add_dependencies(verify check_fb check_calibration check_parameters check_lsqadj check_ray_tracing check_trafo)
+add_dependencies(verify check_fb check_calibration check_parameters check_lsqadj check_ray_tracing check_trafo check_vec_utils)
 

--- a/liboptv/tests/check_lsqadj.c
+++ b/liboptv/tests/check_lsqadj.c
@@ -53,51 +53,6 @@ START_TEST(test_norm_cross)
 }
 END_TEST
 
-
-START_TEST(test_dot)
-{
-
-    double d;
-
-    // test simple cross-product normalized to unity
-
-    double a[] = {1.0, 0.0, 0.0};
-    double b[] = {0.0, 2.0, 0.0};
-
-    dot(a,b,&d);
-
-    //fail_unless( d == 0.0 );
-    ck_assert_msg( fabs(d - 0.0) < EPS,
-             "Was expecting d to be 0.0 but found %f \n", d);
-
-    b[0] = 2.0;
-    b[1] = 2.0;
-    b[2] = 0.0;
-
-    dot(b,a,&d);
-    // fail_unless( d == 2.0 );
-    ck_assert_msg( fabs(d - 2.0) < EPS,
-             "Was expecting d to be 2.0 but found %f \n", d);
-
-}
-END_TEST
-
-
-START_TEST(test_modu)
-{
-    double a[]= {10.0, 0.0, 0.0};
-    double m;
-
-    modu(a,&m);
-
-    // fail_unless( m == 10.0);
-    ck_assert_msg( fabs(m - 10.0) < EPS,
-             "Was expecting m to be 10.0 but found %f \n", m);
-
-}
-END_TEST
-
-
 START_TEST(test_matmul)
 {
 
@@ -220,8 +175,6 @@ Suite* fb_suite(void) {
  
     TCase *tc = tcase_create ("lsadj test");
     tcase_add_test(tc, test_norm_cross);
-    tcase_add_test(tc, test_dot);
-    tcase_add_test(tc, test_modu);
     tcase_add_test(tc, test_matmul);
     tcase_add_test(tc, test_ata);
     tcase_add_test(tc, test_atl);

--- a/liboptv/tests/check_vec_utils.c
+++ b/liboptv/tests/check_vec_utils.c
@@ -1,0 +1,127 @@
+/*  Unit tests for the vector utilities. Uses the Check
+    framework: http://check.sourceforge.net/
+    
+    To run it, type "make check" when in the top C directory, src_c/
+    If that doesn't run the tests, use the Check tutorial:
+    http://check.sourceforge.net/doc/check_html/check_3.html
+*/
+
+#include <check.h>
+#include <stdlib.h>
+#include <math.h>
+#include "vec_utils.h"
+
+#define EPS 1E-5
+
+
+START_TEST(test_dot)
+{
+    // test simple dot-product
+    double d;
+    
+    vec3d a = {1.0, 0.0, 0.0};
+    vec3d b = {0.0, 2.0, 0.0};
+    
+    d = vec_dot(a, b);
+    ck_assert_msg( fabs(d - 0.0) < EPS,
+             "Was expecting d to be 0.0 but found %f \n", d);
+
+    vec_set(b, 2.0, 2.0, 0.0);
+    d = vec_dot(b, a);
+    ck_assert_msg( fabs(d - 2.0) < EPS,
+             "Was expecting d to be 2.0 but found %f \n", d);
+
+}
+END_TEST
+
+START_TEST(test_vec_init)
+{
+    int i;
+    vec3d p;
+    vec_init(p);
+
+    for (i = 0; i < 3; i++)
+        fail_unless(is_empty(p[i]));
+}
+END_TEST
+
+START_TEST(test_vec_cmp)
+{
+    /* Putting it first because it's useful for the other tests */
+    vec3d v1 = {1., 2., 3.}, v2 = {4., 5., 6.};
+    
+    fail_unless(vec_cmp(v1, v1));
+    fail_if(vec_cmp(v1, v2));
+}
+END_TEST
+
+START_TEST(test_vec_copy)
+{
+    vec3d src = {1., 2., 3.}, dst;
+    vec_copy(dst, src);
+
+    fail_unless(vec_cmp(dst, src));
+}
+END_TEST
+
+START_TEST(test_vec_subt)
+{
+    vec3d sub = {1., 2., 3.}, from = {4., 5., 6.}, res = {3., 3., 3.}, out;
+    vec_subt(from, sub, out);
+
+    fail_unless(vec_cmp(out, res));
+}
+END_TEST
+
+START_TEST(test_diff_norm)
+{
+    int i;
+    vec3d vec1 = {1., 2., 3.}, vec2 = {4., 5., 6.};
+    fail_unless(vec_diff_norm(vec1, vec2) == sqrt(3)*3);
+}
+END_TEST
+
+START_TEST(test_vec_set)
+{
+    vec3d res = {1., 2., 3.}, dest;
+    vec_set(dest, 1., 2., 3.);
+    fail_unless(vec_cmp(dest, res));
+}
+END_TEST
+
+Suite* fb_suite(void) {
+    Suite *s = suite_create ("lsqadj");
+ 
+    TCase *tc = tcase_create ("Vector dot product");
+    tcase_add_test(tc, test_dot);
+    suite_add_tcase (s, tc);   
+    
+    tc = tcase_create("Init vec3d");
+    tcase_add_test(tc, test_vec_init);
+    suite_add_tcase (s, tc);
+    
+    tc = tcase_create("Copy vec3d");
+    tcase_add_test(tc, test_vec_copy);
+    suite_add_tcase (s, tc);
+
+    tc = tcase_create("Subtract vec3d");
+    tcase_add_test(tc, test_vec_subt);
+    suite_add_tcase (s, tc);
+
+    tc = tcase_create("Compare vec3d");
+    tcase_add_test(tc, test_vec_cmp);
+    suite_add_tcase (s, tc);
+
+    return s;
+}
+
+int main(void) {
+    int number_failed;
+    Suite *s = fb_suite ();
+    SRunner *sr = srunner_create (s);
+    srunner_run_all (sr, CK_ENV);
+    number_failed = srunner_ntests_failed (sr);
+    srunner_free (sr);
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+

--- a/liboptv/tests/check_vec_utils.c
+++ b/liboptv/tests/check_vec_utils.c
@@ -55,6 +55,15 @@ START_TEST(test_vec_cmp)
 }
 END_TEST
 
+START_TEST(test_vec_approx_cmp)
+{
+    vec3d v1 = {1., 2., 3.}, v2 = {1.00001, 2.00001, 3.00001};
+    
+    fail_unless(vec_approx_cmp(v1, v2, 1e-4));
+    fail_if(vec_approx_cmp(v1, v2, 1e-5));
+}
+END_TEST
+
 START_TEST(test_vec_copy)
 {
     vec3d src = {1., 2., 3.}, dst;
@@ -89,6 +98,15 @@ START_TEST(test_vec_set)
 }
 END_TEST
 
+START_TEST(test_scalar_mul)
+{
+    vec3d v1 = {1., 2., 3.}, v2 = {4., 8., 12.}, out;
+    vec_scalar_mul(v1, 4., out);
+
+    fail_unless(vec_cmp(out, v2));
+}
+END_TEST
+
 Suite* fb_suite(void) {
     Suite *s = suite_create ("lsqadj");
  
@@ -110,6 +128,18 @@ Suite* fb_suite(void) {
 
     tc = tcase_create("Compare vec3d");
     tcase_add_test(tc, test_vec_cmp);
+    suite_add_tcase (s, tc);
+
+    tc = tcase_create("Approx. compare vec3d");
+    tcase_add_test(tc, test_vec_approx_cmp);
+    suite_add_tcase (s, tc);
+    
+    tc = tcase_create("Set vec3d");
+    tcase_add_test(tc, test_vec_set);
+    suite_add_tcase (s, tc);
+
+    tc = tcase_create("Multiply vec3d by scalar");
+    tcase_add_test(tc, test_scalar_mul);
     suite_add_tcase (s, tc);
 
     return s;


### PR DESCRIPTION
Add a typedef for a 3D vector, then facilities for manipulating it. Includes tests.

I need this if I'm going to start moving into liboptv all of the multimedia/image-processing codes that transform global to image coordinates and vice versa.

Note: it removes from lsqadj two functions that are now in vec_utils.