### PR TITLE
Distribute pxd files with the installed package.

### DIFF
--- a/py_bind/setup.py
+++ b/py_bind/setup.py
@@ -24,6 +24,7 @@ setup(
     cmdclass = {'build_ext': build_ext},
     packages=['optv'],
     ext_modules = ext_mods,
+    package_data = {'optv': ['*.pxd']}
 )
 
 


### PR DESCRIPTION
Adds to the installed package the Cython declarations needed for using the Cython bindings from other Cython files external to this package. A one-liner, really.