### PR TITLE
Image processing functions

### DIFF
--- a/liboptv/include/image_processing.h
+++ b/liboptv/include/image_processing.h
@@ -11,6 +11,9 @@ typedef double filter_t[3][3];
 int filter_3(unsigned char *img, unsigned char *img_lp, filter_t filt,
     control_par *cpar);
 void lowpass_3(unsigned char *img, unsigned char *img_lp, control_par *cpar);
+int fast_box_blur(int filt_span, unsigned char *src, unsigned char *dest, 
+    control_par *cpar);
+void split(unsigned char *img, int half_selector, control_par *cpar);
 
 #endif
 

--- a/liboptv/include/image_processing.h
+++ b/liboptv/include/image_processing.h
@@ -1,0 +1,15 @@
+
+/* Forward declarations for various image processing routines */
+
+#ifndef IMAGE_PROCESSING_C
+#define IMAGE_PROCESSING_C
+
+#include "parameters.h"
+
+typedef double filter_t[3][3];
+
+int filter_3(unsigned char *img, unsigned char *img_lp, filter_t filt,
+    control_par *cpar);
+
+#endif
+

--- a/liboptv/include/image_processing.h
+++ b/liboptv/include/image_processing.h
@@ -10,6 +10,7 @@ typedef double filter_t[3][3];
 
 int filter_3(unsigned char *img, unsigned char *img_lp, filter_t filt,
     control_par *cpar);
+void lowpass_3(unsigned char *img, unsigned char *img_lp, control_par *cpar);
 
 #endif
 

--- a/liboptv/src/CMakeLists.txt
+++ b/liboptv/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 include_directories("../include/")
-add_library (optv SHARED tracking_frame_buf.c calibration.c parameters.c lsqadj.c ray_tracing.c trafo.c vec_utils.c)
+add_library (optv SHARED tracking_frame_buf.c calibration.c parameters.c lsqadj.c ray_tracing.c trafo.c vec_utils.c image_processing.c)
 
 
 if(UNIX)

--- a/liboptv/src/image_processing.c
+++ b/liboptv/src/image_processing.c
@@ -9,6 +9,26 @@
 
 #include "image_processing.h"
 
+/*  This would be a function, only the original writer of these filters put a 
+    lot of emphasis on speed and used 'register' variables. this probably does 
+    nothing on a modern compiler, esp. in 32 bit where there are simply not 
+    enough registers, but I honor the intent by inlining this function. */
+#define setup_filter_pointers(line) \
+    ptr  = img_lp + (line) + 1;\
+\
+    ptr1 = img;\
+    ptr2 = img + 1;\
+    ptr3 = img + 2;\
+\
+    ptr4 = img + (line);\
+    ptr5 = ptr4 + 1;\
+    ptr6 = ptr4 + 2;\
+\
+    ptr7 = img + 2*(line);\
+    ptr8 = ptr7 + 1;\
+    ptr9 = ptr7 + 2;\
+
+
 /*  filter_3() performs a 3x3 filtering over an image. The first and last 
     lines are not processed at all, the rest uses wrap-around on the image
     edges. Minimal brightness output in processed pixels is 8.
@@ -41,19 +61,7 @@ int filter_3(unsigned char *img, unsigned char *img_lp, filter_t filt,
     /* start, end etc skip first/last lines and wrap around the edges. */
     end = image_size - cpar->imx - 1;
     
-    ptr  = img_lp + cpar->imx + 1;
-    ptr1 = img;
-    ptr2 = img + 1;
-    ptr3 = img + 2;
-    
-    ptr4 = img + cpar->imx;
-    ptr5 = ptr4 + 1;
-    ptr6 = ptr4 + 2;
-    
-    ptr7 = img + 2*cpar->imx;
-    ptr8 = ptr7 + 1;
-    ptr9 = ptr7 + 2;
-
+    setup_filter_pointers(cpar->imx)
     for (i = cpar->imx + 1; i < end; i++) {
         buf = filt[0][0] * *ptr1++ + filt[0][1] * *ptr2++ + filt[0][2] * *ptr3++
             + filt[1][0] * *ptr4++ + filt[1][1] * *ptr5++ + filt[1][2] * *ptr6++
@@ -89,19 +97,7 @@ void lowpass_3(unsigned char *img, unsigned char *img_lp, control_par *cpar) {
     /* start, end etc skip first/last lines and wrap around the edges. */
     end = image_size - cpar->imx - 1;
     
-    ptr  = img_lp + cpar->imx + 1;
-    ptr1 = img;
-    ptr2 = img + 1;
-    ptr3 = img + 2;
-    
-    ptr4 = img + cpar->imx;
-    ptr5 = ptr4 + 1;
-    ptr6 = ptr4 + 2;
-    
-    ptr7 = img + 2*cpar->imx;
-    ptr8 = ptr7 + 1;
-    ptr9 = ptr7 + 2;
-
+    setup_filter_pointers(cpar->imx)
     for (i = cpar->imx + 1; i < end; i++) {
         buf = *ptr5++ + *ptr1++ + *ptr2++ + *ptr3++ + *ptr4++
                       + *ptr6++ + *ptr7++ + *ptr8++ + *ptr9++;

--- a/liboptv/src/image_processing.c
+++ b/liboptv/src/image_processing.c
@@ -216,8 +216,9 @@ int fast_box_blur(int filt_span, unsigned char *src, unsigned char *dest,
     }
     
     /* Middle lines with filter-size lines around them */
-    for (i = n+1, ptr1 = row_accum, ptrz = dest + cpar->imx*(n + 1), 
-        ptr2 = row_accum + cpar->imx*n; i < cpar->imy - n; i++)
+    for (i = filt_span + 1, ptr1 = row_accum, 
+        ptrz = dest + cpar->imx*(filt_span + 1),
+        ptr2 = row_accum + cpar->imx*n; i < cpar->imy - filt_span; i++)
     {
         for (ptr3 = col_accum; ptr3 < end; ptr3++, ptr1++, ptrz++, ptr2++) {
            *ptr3 += (*ptr2 - *ptr1);
@@ -226,7 +227,7 @@ int fast_box_blur(int filt_span, unsigned char *src, unsigned char *dest,
     }
     
     /* Last lines, similarly to first lines */
-    for (i = n; i > 0; i--) {
+    for (i = filt_span; i > 0; i--) {
         ptr1 = row_accum + (cpar->imy - 2*i - 1)*cpar->imx;
         ptr2 = ptr1 + cpar->imx;
         ptrz = dest + (cpar->imy-i)*cpar->imx;

--- a/liboptv/src/image_processing.c
+++ b/liboptv/src/image_processing.c
@@ -69,3 +69,43 @@ int filter_3(unsigned char *img, unsigned char *img_lp, filter_t filt,
     }
 }
 
+
+/*  This is a reduced version with a constant meadian filter (average of all 9
+    pixels in filter range). It also does not enforce minimal brightness.
+    
+    Arguments:
+    unsigned char *img - original image.
+    unsigned char *img_lp - results buffer, same size as original image.
+    control_par *cpar - contains image size parameters.
+*/
+void lowpass_3(unsigned char *img, unsigned char *img_lp, control_par *cpar) {
+    register unsigned char  *ptr, *ptr1, *ptr2, *ptr3, *ptr4, *ptr5, *ptr6,
+        *ptr7, *ptr8, *ptr9;
+    int end;
+    short buf;
+    register int i;
+    int image_size = cpar->imx * cpar->imy;
+    
+    /* start, end etc skip first/last lines and wrap around the edges. */
+    end = image_size - cpar->imx - 1;
+    
+    ptr  = img_lp + cpar->imx + 1;
+    ptr1 = img;
+    ptr2 = img + 1;
+    ptr3 = img + 2;
+    
+    ptr4 = img + cpar->imx;
+    ptr5 = ptr4 + 1;
+    ptr6 = ptr4 + 2;
+    
+    ptr7 = img + 2*cpar->imx;
+    ptr8 = ptr7 + 1;
+    ptr9 = ptr7 + 2;
+
+    for (i = cpar->imx + 1; i < end; i++) {
+        buf = *ptr5++ + *ptr1++ + *ptr2++ + *ptr3++ + *ptr4++
+                      + *ptr6++ + *ptr7++ + *ptr8++ + *ptr9++;
+        *ptr++ = buf/9;
+    }
+}
+

--- a/liboptv/src/image_processing.c
+++ b/liboptv/src/image_processing.c
@@ -1,0 +1,71 @@
+/****************************************************************************
+ *
+ * Image processing routines.
+ *
+ * Routines contained:    	
+ *   filter_3:	3*3 filter, reads matrix from filter.par
+ *
+ ***************************************************************************/
+
+#include "image_processing.h"
+
+/*  filter_3() performs a 3x3 filtering over an image. The first and last 
+    lines are not processed at all, the rest uses wrap-around on the image
+    edges. Minimal brightness output in processed pixels is 8.
+
+    Arguments:
+    unsigned char *img - original image.
+    unsigned char *img_lp - results buffer, same size as original image.
+    filter_t filt - the 3x3 matrix to apply to the image.
+    control_par *cpar - contains image size parameters.
+    
+    Returns:
+    0 if the filter is bad (all zeros), 1 otherwise.
+*/
+int filter_3(unsigned char *img, unsigned char *img_lp, filter_t filt, 
+    control_par *cpar) {
+    
+    register unsigned char  *ptr, *ptr1, *ptr2, *ptr3, *ptr4, *ptr5, *ptr6,
+        *ptr7, *ptr8, *ptr9;
+	int end;
+	double sum = 0;
+	short buf;
+	register int i, j;
+    int image_size = cpar->imx * cpar->imy;
+
+    for (i = 0; i < 3; i++)	
+        for (j = 0; j < 3; j++)
+            sum += filt[i][j];
+    if (sum == 0) return 0;
+    
+    /* start, end etc skip first/last lines and wrap around the edges. */
+    end = image_size - cpar->imx - 1;
+    
+    ptr  = img_lp + cpar->imx + 1;
+    ptr1 = img;
+    ptr2 = img + 1;
+    ptr3 = img + 2;
+    
+    ptr4 = img + cpar->imx;
+    ptr5 = ptr4 + 1;
+    ptr6 = ptr4 + 2;
+    
+    ptr7 = img + 2*cpar->imx;
+    ptr8 = ptr7 + 1;
+    ptr9 = ptr7 + 2;
+
+    for (i = cpar->imx + 1; i < end; i++) {
+        buf = filt[0][0] * *ptr1++ + filt[0][1] * *ptr2++ + filt[0][2] * *ptr3++
+            + filt[1][0] * *ptr4++ + filt[1][1] * *ptr5++ + filt[1][2] * *ptr6++
+            + filt[2][0] * *ptr7++ + filt[2][1] * *ptr8++ + filt[2][2] * *ptr9++;
+        buf /= sum;
+        
+        if (buf > 255)
+            buf = 255;
+        if (buf < 8)
+            buf = 8;
+        
+        *ptr++ = buf;
+    }
+}
+

--- a/liboptv/src/image_processing.c
+++ b/liboptv/src/image_processing.c
@@ -50,7 +50,7 @@ int filter_3(unsigned char *img, unsigned char *img_lp, filter_t filt,
         *ptr7, *ptr8, *ptr9;
 	int end;
 	double sum = 0;
-	short buf;
+	unsigned short buf;
 	register int i, j;
     int image_size = cpar->imx * cpar->imy;
 
@@ -74,8 +74,9 @@ int filter_3(unsigned char *img, unsigned char *img_lp, filter_t filt,
         if (buf < 8)
             buf = 8;
         
-        *ptr++ = buf;
+        *ptr++ = (unsigned char) buf;
     }
+    return 1;
 }
 
 

--- a/liboptv/src/image_processing.c
+++ b/liboptv/src/image_processing.c
@@ -7,6 +7,7 @@
  *
  ***************************************************************************/
 
+#include <stdlib.h>
 #include "image_processing.h"
 
 /*  This would be a function, only the original writer of these filters put a 
@@ -104,4 +105,143 @@ void lowpass_3(unsigned char *img, unsigned char *img_lp, control_par *cpar) {
         *ptr++ = buf/9;
     }
 }
+
+
+/*  fast_box_blur() performs a box blur of an image using a given kernel size.
+    It is equivalent to using an all-ones kernel of the given size in a 
+    function like filter_3 (but adjusted to size). However, this algorithm runs
+    in linear filter-size time instead of quadratic (it's still quadratic in 
+    image size).
+    
+    Arguments:
+    int filt_span - how many pixels to take for the average on each side. The
+        equivalent filter kernel is of side 2*filt_size + 1.
+    unsigned char *src - points to the source image.
+    unsigned char *dest - points to same-size memory block allocated for the 
+        result.
+    control_par *cpar - contains image size parameters.
+    
+    Returns:
+    0 on failure (due to memory allocation error), 1 on success.
+    
+    References:
+    [1] http://www.filtermeister.com/tutorials/blur01.html
+    [2] http://www.gamasutra.com/view/feature/131511/four_tricks_for_fast_blurring_in_.php
+*/
+int fast_box_blur(int filt_span, unsigned char *src, unsigned char *dest, 
+    control_par *cpar) 
+{
+    register unsigned char  *ptrl, *ptrr, *ptrz;
+    register int *ptr, *ptr1, *ptr2, *ptr3;
+    int *row_accum, *col_accum, accum, *end;
+    int row_start, n, nq, m;
+    register int i;
+    int image_size = cpar->imx * cpar->imy;
+    
+    n = 2*filt_span + 1;
+    nq = n*n;
+    
+    if ((row_accum = (int *)calloc(image_size, sizeof(int))) == NULL) return 0;
+    if ((col_accum = (int *)calloc(cpar->imx, sizeof(int))) == NULL) return 0;
+    
+    /* Sum over lines first [1]: */
+    for (i = 0; i < cpar->imy; i++) {
+        row_start = i * cpar->imx;
+        
+        /* first element has no filter around him */
+        accum = *(src + row_start);
+        *(row_accum + row_start) = accum * n;
+        
+        /* Elements 1..filt_span have a growing filter, as much as fits.
+           Each iteration increases the filter symmetrically, so 2 new elements 
+           are taken.
+        */
+        for (ptr = row_accum + row_start + 1, 
+            ptrr = src + row_start + 2, ptrl = ptrr - 1, m = 3;
+            ptr < row_accum + row_start + 1 + filt_span;
+            ptr++, ptrl+=2, ptrr+=2, m+=2) 
+        {    
+            accum += (*ptrl + *ptrr);
+            *ptr = accum * n / m; /* So small filters have same weight as
+                                         the largest size */
+        }
+        
+        /* Middle elements, having a constant-size filter. The sum is obtained
+           by adding the coming element and dropping the leaving element, in a 
+           sliding window fashion. 
+        */
+        for (ptr = row_accum + row_start + filt_span + 1,
+            ptrl = src + row_start, ptrr = src + row_start + n;
+            ptrr < src + row_start + cpar->imx;
+            ptrl++, ptr++, ptrr++)
+        {
+            accum += (*ptrr - *ptrl);
+            *ptr = accum;
+        }
+        
+        /* last elements in line treated like first ones, mutatis mutandis */
+        for (ptrl = src + row_start + cpar->imx - n,
+            ptrr = ptrl + 1, m = n - 2,
+            ptr = row_accum + row_start + cpar->imx - filt_span;
+            ptr < row_accum + row_start + cpar->imx;
+            ptrl += 2, ptrr += 2, ptr++, m-=2)
+        {
+            accum -= (*ptrl + *ptrr);
+            *ptr = accum * n / m;
+        }
+    }
+    
+    /* Sum over columns: */
+    
+    end = col_accum + cpar->imx;
+    
+    /* first line */
+    for (ptr1 = row_accum, ptr2 = col_accum, ptrz = dest; 
+        ptr2 < end; ptr1++, ptr2++, ptrz++)
+    {
+       *ptr2 = *ptr1;
+       *ptrz = *ptr2/n;
+    }
+    
+    /* Sum vertically the accumulated row values for lines 1 ... filt_span */
+    for (i = 1; i <= filt_span; i++) {
+        ptr1 = row_accum + (2*i - 1)*cpar->imx;
+        ptr2 = ptr1 + cpar->imx;
+        ptrz = dest + i*cpar->imx;
+        
+        for (ptr3 = col_accum; ptr3 < end; ptr1++, ptr2++, ptr3++, ptrz++) {
+            *ptr3 += (*ptr1 + *ptr2);
+            *ptrz = n * (*ptr3) / nq / (2*i + 1);
+        }
+    }
+    
+    /* Middle lines with filter-size lines around them */
+    for (i = n+1, ptr1 = row_accum, ptrz = dest + cpar->imx*(n + 1), 
+        ptr2 = row_accum + cpar->imx*n; i < cpar->imy - n; i++)
+    {
+        for (ptr3 = col_accum; ptr3 < end; ptr3++, ptr1++, ptrz++, ptr2++) {
+           *ptr3 += (*ptr2 - *ptr1);
+           *ptrz = *ptr3/nq;
+        }
+    }
+    
+    /* Last lines, similarly to first lines */
+    for (i = n; i > 0; i--) {
+        ptr1 = row_accum + (cpar->imy - 2*i - 1)*cpar->imx;
+        ptr2 = ptr1 + cpar->imx;
+        ptrz = dest + (cpar->imy-i)*cpar->imx;
+        
+        for (ptr3 = col_accum; ptr3 < end; ptr1++, ptr2++, ptr3++, ptrz++) {
+            *ptr3 -= (*ptr1 + *ptr2);
+            *ptrz = n * (*ptr3) / nq / (2*i+1);
+        }
+    }
+    
+    /* ``dest`` now contains result. Finish up. */
+    free(row_accum);
+    free(col_accum);
+    
+    return 1;
+}
+
 

--- a/liboptv/src/image_processing.c
+++ b/liboptv/src/image_processing.c
@@ -246,3 +246,32 @@ int fast_box_blur(int filt_span, unsigned char *src, unsigned char *dest,
 }
 
 
+/*  split() crams into the first half of a given image either its even or odd 
+    lines. Used with interlaced cameras, a mostly obsolete device.
+    The lower half of the image is set to the number 2.
+    
+    Arguments:
+    unsigned char *img - the image to modify. Both input and output.
+    int half_selector - 0 to do nothing, 1 to take odd rows, 2 for even rows
+    control_par *cpar - contains image size parameters.
+*/
+void split(unsigned char *img, int half_selector, control_par *cpar) {
+    register int row, col;
+    register unsigned char *ptr;
+    unsigned char *end;
+    int image_size = cpar->imx * cpar->imy;
+    int cond_offs = (half_selector % 2) ? (cpar->imx) : (0);
+    
+    if (half_selector == 0)
+        return;
+    
+    for (row = 0; row < cpar->imy/2; row++)
+        for (col = 0; col < cpar->imx; col++)
+            img[row*cpar->imx + col] = img[2*row*cpar->imx + cond_offs + col];
+    
+    /* Erase lower half with magic 2 */
+    end = img + image_size;
+    for (ptr = img + image_size/2; ptr < end; ptr++)
+        *ptr = 2;
+}
+

--- a/liboptv/tests/CMakeLists.txt
+++ b/liboptv/tests/CMakeLists.txt
@@ -24,6 +24,9 @@ add_dependencies(check_trafo optv)
 add_executable(check_vec_utils EXCLUDE_FROM_ALL check_vec_utils.c)
 add_dependencies(check_vec_utils optv)
 
+add_executable(check_image_proc EXCLUDE_FROM_ALL check_image_proc.c)
+add_dependencies(check_image_proc optv)
+
 get_property(OPTV_LIBRARY TARGET optv PROPERTY LOCATION)
 set(LIBS ${LIBS} ${CHECK_LIBRARIES} ${OPTV_LIBRARY})
 
@@ -83,6 +86,9 @@ add_custom_command(TARGET check_trafo PRE_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory
     ${CMAKE_CURRENT_SOURCE_DIR}/testing_fodder $<TARGET_FILE_DIR:check_trafo>/testing_fodder)    
 
+target_link_libraries(check_image_proc ${LIBS})
+add_test(check_image_proc ${CMAKE_CURRENT_BINARY_DIR}/check_image_proc)
+    
 add_custom_target(verify COMMAND ${CMAKE_CTEST_COMMAND})
-add_dependencies(verify check_fb check_calibration check_parameters check_lsqadj check_ray_tracing check_trafo check_vec_utils)
+add_dependencies(verify check_fb check_calibration check_parameters check_lsqadj check_ray_tracing check_trafo check_vec_utils check_image_proc)
 

--- a/liboptv/tests/check_image_proc.c
+++ b/liboptv/tests/check_image_proc.c
@@ -1,0 +1,77 @@
+/*  Unit tests for functions related to image processing. Uses the Check
+    framework: http://check.sourceforge.net/
+    
+    To run it, type "make verify" when in the build/ directory created for 
+    CMake.
+*/
+
+#include <check.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "parameters.h"
+#include "image_processing.h"
+
+int images_equal(unsigned char *img1, unsigned char *img2, int w, int h) {
+    int pix;
+    
+    for (pix = w; pix < w*h; pix++) {
+        printf("%d == %d; ", img1[pix], img2[pix]);
+        if (img1[pix] != img2[pix])
+            return 0; }
+    return 1;
+}
+
+START_TEST(test_general_filter)
+{
+    filter_t blur_filt = {{0, 0.2, 0}, {0.2, 0.2, 0.2}, {0, 0.2, 0}};
+    unsigned char img[5][5] = {
+        { 0,   0,   0,   0, 0},
+        { 0, 255, 255, 255, 0},
+        { 0, 255, 255, 255, 0},
+        { 0, 255, 255, 255, 0},
+        { 0,   0,   0,   0, 0}
+    };
+
+    unsigned char img_correct[5][5] = {
+        {  0,   0,   0,   0,  0},
+        {  0, 153, 204, 153, 51},
+        { 51, 204, 255, 204, 51},
+        { 51, 153, 204, 153,  0},
+        { 0,   0,   0,   0,   0}
+    };
+
+    control_par cpar = {
+        .imx = 5,
+        .imy = 5,
+    };
+    
+    unsigned char *img_filt = (unsigned char *) malloc(cpar.imx*cpar.imy* \
+        sizeof(unsigned char));
+    
+    filter_3(img, img_filt, blur_filt, &cpar);
+    fail_unless(images_equal(img_filt, img_correct, 5, 5));
+    free(img_filt);
+}
+END_TEST
+
+Suite* fb_suite(void) {
+    Suite *s = suite_create ("Image processing");
+
+    TCase *tc = tcase_create ("General filter");
+    tcase_add_test(tc, test_general_filter);
+    suite_add_tcase (s, tc);
+
+    return s;
+}
+
+int main(void) {
+    int number_failed;
+    Suite *s = fb_suite ();
+    SRunner *sr = srunner_create (s);
+    srunner_run_all (sr, CK_ENV);
+    number_failed = srunner_ntests_failed (sr);
+    srunner_free (sr);
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+

--- a/liboptv/tests/check_image_proc.c
+++ b/liboptv/tests/check_image_proc.c
@@ -55,11 +55,45 @@ START_TEST(test_general_filter)
 }
 END_TEST
 
+START_TEST(test_mean_filter)
+{
+    filter_t mean_filt = {{1, 1, 1}, {1, 1, 1}, {1, 1, 1}};
+    unsigned char img[5][5] = {
+        { 0,   0,   0,   0, 0},
+        { 0, 255, 255, 255, 0},
+        { 0, 255, 255, 255, 0},
+        { 0, 255, 255, 255, 0},
+        { 0,   0,   0,   0, 0}
+    };
+
+    control_par cpar = {
+        .imx = 5,
+        .imy = 5,
+    };
+    
+    unsigned char *img_filt = (unsigned char *) malloc(cpar.imx*cpar.imy* \
+        sizeof(unsigned char));
+    unsigned char *img_mean = (unsigned char *) malloc(cpar.imx*cpar.imy* \
+        sizeof(unsigned char));
+    
+    filter_3(img, img_filt, mean_filt, &cpar);
+    lowpass_3(img, img_mean, &cpar);
+    fail_unless(images_equal(img_filt, img_mean, 5, 5));
+    
+    free(img_filt);
+    free(img_mean);
+}
+END_TEST
+
 Suite* fb_suite(void) {
     Suite *s = suite_create ("Image processing");
 
     TCase *tc = tcase_create ("General filter");
     tcase_add_test(tc, test_general_filter);
+    suite_add_tcase (s, tc);
+
+    tc = tcase_create ("Mean (lowpass) filter");
+    tcase_add_test(tc, test_mean_filter);
     suite_add_tcase (s, tc);
 
     return s;

--- a/liboptv/tests/check_image_proc.c
+++ b/liboptv/tests/check_image_proc.c
@@ -17,17 +17,18 @@
     Arguments:
     unsigned char *img1, *img2 - images to compare.
     int w, h - width and height of images in pixels
-    offset - start comparing after this many elements.
+    int offset - start comparing after this many elements.
+    int discard - don't compare this many elements from the end.
     
     Returns:
     1 if equal, 0 if not.
 */
 int images_equal(unsigned char *img1, unsigned char *img2, 
-    int w, int h, int offset) 
+    int w, int h, int offset, int discard) 
 {
     int pix;
     
-    for (pix = offset; pix < w*h; pix++)
+    for (pix = offset; pix < w*h - discard; pix++)
         if (img1[pix] != img2[pix])
             return 0; 
     return 1;
@@ -61,7 +62,7 @@ START_TEST(test_general_filter)
         sizeof(unsigned char));
     
     filter_3(img, img_filt, blur_filt, &cpar);
-    fail_unless(images_equal(img_filt, img_correct, 5, 5, 5));
+    fail_unless(images_equal(img_filt, img_correct, 5, 5, 6, 6));
     free(img_filt);
 }
 END_TEST
@@ -89,7 +90,7 @@ START_TEST(test_mean_filter)
     
     filter_3(img, img_filt, mean_filt, &cpar);
     lowpass_3(img, img_mean, &cpar);
-    fail_unless(images_equal(img_filt, img_mean, 5, 5, 5));
+    fail_unless(images_equal(img_filt, img_mean, 5, 5, 6, 6));
     
     free(img_filt);
     free(img_mean);
@@ -131,7 +132,7 @@ START_TEST(test_box_blur)
         img_mean[5*elem + 4] = 0;
     }
     
-    fail_unless(images_equal(img_filt, img_mean, 5, 5, 5));
+    fail_unless(images_equal(img_filt, img_mean, 5, 5, 6, 6));
     
     free(img_filt);
     free(img_mean);
@@ -177,13 +178,15 @@ START_TEST(test_split)
     memcpy(img1, img, 25);
     memcpy(img2, img, 25);
     
+    /* Note: first line of erased half is only erased from the middle, 
+       for historic reasons. */
     split(img1, 1, &cpar);
-    fail_unless(images_equal(img1, img_odd, 5, 2, 0));
-    fail_unless(images_equal(&(img1[2]), erased_half, 5, 3, 2));
+    fail_unless(images_equal(img1, img_odd, 5, 2, 0, 0));
+    fail_unless(images_equal(&(img1[2]), erased_half, 5, 3, 2, 0));
     
     split(img2, 2, &cpar);
-    fail_unless(images_equal(img2, img_even, 5, 2, 0));
-    fail_unless(images_equal(&(img2[2]), erased_half, 5, 3, 2));
+    fail_unless(images_equal(img2, img_even, 5, 2, 0, 0));
+    fail_unless(images_equal(&(img2[2]), erased_half, 5, 3, 2, 0));
 }
 END_TEST
 

--- a/liboptv/tests/check_image_proc.c
+++ b/liboptv/tests/check_image_proc.c
@@ -12,10 +12,22 @@
 #include "parameters.h"
 #include "image_processing.h"
 
-int images_equal(unsigned char *img1, unsigned char *img2, int w, int h) {
+/*  Check equality of (parts of) images.
+    
+    Arguments:
+    unsigned char *img1, *img2 - images to compare.
+    int w, h - width and height of images in pixels
+    offset - start comparing after this many elements.
+    
+    Returns:
+    1 if equal, 0 if not.
+*/
+int images_equal(unsigned char *img1, unsigned char *img2, 
+    int w, int h, int offset) 
+{
     int pix;
     
-    for (pix = w; pix < w*h; pix++) 
+    for (pix = offset; pix < w*h; pix++)
         if (img1[pix] != img2[pix])
             return 0; 
     return 1;
@@ -49,7 +61,7 @@ START_TEST(test_general_filter)
         sizeof(unsigned char));
     
     filter_3(img, img_filt, blur_filt, &cpar);
-    fail_unless(images_equal(img_filt, img_correct, 5, 5));
+    fail_unless(images_equal(img_filt, img_correct, 5, 5, 5));
     free(img_filt);
 }
 END_TEST
@@ -77,7 +89,7 @@ START_TEST(test_mean_filter)
     
     filter_3(img, img_filt, mean_filt, &cpar);
     lowpass_3(img, img_mean, &cpar);
-    fail_unless(images_equal(img_filt, img_mean, 5, 5));
+    fail_unless(images_equal(img_filt, img_mean, 5, 5, 5));
     
     free(img_filt);
     free(img_mean);
@@ -119,10 +131,59 @@ START_TEST(test_box_blur)
         img_mean[5*elem + 4] = 0;
     }
     
-    fail_unless(images_equal(img_filt, img_mean, 5, 5));
+    fail_unless(images_equal(img_filt, img_mean, 5, 5, 5));
     
     free(img_filt);
     free(img_mean);
+}
+END_TEST
+
+START_TEST(test_split)
+{
+    /*  A 3x3 box-blur is equivalent to lowpass_3, so that's the comparison
+        we'll make here. Only difference is highpass_3 wraps around rows so
+        it has different values at the edges. */
+    int elem;
+    
+    unsigned char img[5][5] = {
+        { 0,   0,   0,   0, 0},
+        { 0, 255, 255, 255, 0},
+        { 0, 255, 255, 255, 0},
+        { 0, 255, 255, 255, 0},
+        { 0,   0,   0,   0, 0}
+    }, img1[5][5], img2[5][5];
+    
+    unsigned char img_even[2][5] = {
+        { 0,   0,   0,   0, 0},
+        { 0, 255, 255, 255, 0}
+    };
+    
+    unsigned char img_odd[2][5] = {
+        { 0, 255, 255, 255, 0},
+        { 0, 255, 255, 255, 0}
+    };
+    
+    unsigned char erased_half[3][5] = {
+        { 2, 2, 2, 2, 2},
+        { 2, 2, 2, 2, 2},
+        { 2, 2, 2, 2, 2}
+    };
+
+    control_par cpar = {
+        .imx = 5,
+        .imy = 5,
+    };
+    
+    memcpy(img1, img, 25);
+    memcpy(img2, img, 25);
+    
+    split(img1, 1, &cpar);
+    fail_unless(images_equal(img1, img_odd, 5, 2, 0));
+    fail_unless(images_equal(&(img1[2]), erased_half, 5, 3, 2));
+    
+    split(img2, 2, &cpar);
+    fail_unless(images_equal(img2, img_even, 5, 2, 0));
+    fail_unless(images_equal(&(img2[2]), erased_half, 5, 3, 2));
 }
 END_TEST
 
@@ -141,6 +202,10 @@ Suite* fb_suite(void) {
     tcase_add_test(tc, test_box_blur);
     suite_add_tcase (s, tc);
     
+    tc = tcase_create ("Split image");
+    tcase_add_test(tc, test_split);
+    suite_add_tcase (s, tc);
+
     return s;
 }
 

--- a/liboptv/tests/check_image_proc.c
+++ b/liboptv/tests/check_image_proc.c
@@ -15,10 +15,9 @@
 int images_equal(unsigned char *img1, unsigned char *img2, int w, int h) {
     int pix;
     
-    for (pix = w; pix < w*h; pix++) {
-        printf("%d == %d; ", img1[pix], img2[pix]);
+    for (pix = w; pix < w*h; pix++) 
         if (img1[pix] != img2[pix])
-            return 0; }
+            return 0; 
     return 1;
 }
 
@@ -85,6 +84,48 @@ START_TEST(test_mean_filter)
 }
 END_TEST
 
+START_TEST(test_box_blur)
+{
+    /*  A 3x3 box-blur is equivalent to lowpass_3, so that's the comparison
+        we'll make here. Only difference is highpass_3 wraps around rows so
+        it has different values at the edges. */
+    int elem;
+    
+    unsigned char img[5][5] = {
+        { 0,   0,   0,   0, 0},
+        { 0, 255, 255, 255, 0},
+        { 0, 255, 255, 255, 0},
+        { 0, 255, 255, 255, 0},
+        { 0,   0,   0,   0, 0}
+    };
+
+    control_par cpar = {
+        .imx = 5,
+        .imy = 5,
+    };
+    
+    unsigned char *img_filt = (unsigned char *) malloc(cpar.imx*cpar.imy* \
+        sizeof(unsigned char));
+    unsigned char *img_mean = (unsigned char *) malloc(cpar.imx*cpar.imy* \
+        sizeof(unsigned char));
+    
+    fast_box_blur(1, img, img_filt, &cpar);
+    lowpass_3(img, img_mean, &cpar);
+    
+    /*  set lowpass edge values to 0 so it equals the no-wrap action of 
+        the fast box blur */
+    for (elem = 0; elem < 6; elem++) {
+        img_mean[5*elem] = 0;
+        img_mean[5*elem + 4] = 0;
+    }
+    
+    fail_unless(images_equal(img_filt, img_mean, 5, 5));
+    
+    free(img_filt);
+    free(img_mean);
+}
+END_TEST
+
 Suite* fb_suite(void) {
     Suite *s = suite_create ("Image processing");
 
@@ -96,6 +137,10 @@ Suite* fb_suite(void) {
     tcase_add_test(tc, test_mean_filter);
     suite_add_tcase (s, tc);
 
+    tc = tcase_create ("Fast box blur");
+    tcase_add_test(tc, test_box_blur);
+    suite_add_tcase (s, tc);
+    
     return s;
 }
 


### PR DESCRIPTION
This brings in everything that is still somewhere used in PyPTV from the image processing code.

Note especcially the fast_box_blur function, which is a cleaned-up version of unsharp_mask. It actually only creates the blurred mask, which is later subtracted from the image somewhere else to sharpen the image (highpass). Here and in other functions I added references and comments to make it easier for a newcomer to understand what is going on.

Naturally, unit tests are included.
