### PR TITLE
fix to the automatic link to the Check library that is not found on Mac

### DIFF
--- a/liboptv/tests/CMakeLists.txt
+++ b/liboptv/tests/CMakeLists.txt
@@ -2,6 +2,7 @@ enable_testing()
 find_package(Check REQUIRED)
 include_directories(${CHECK_INCLUDE_DIRS})
 include_directories(. ../src ../include/)
+link_directories(${CHECK_LIBRARY_DIRS})
 
 add_executable(check_fb EXCLUDE_FROM_ALL check_fb.c)
 add_dependencies(check_fb optv)


### PR DESCRIPTION
Please consider including this fix in the main branch - solves all the linking problems I have and seems to be generic enough 