### PR TITLE
Fix: sensor shift ignored in img_coord

### DIFF
--- a/liboptv/src/imgcoord.c
+++ b/liboptv/src/imgcoord.c
@@ -69,6 +69,8 @@ void flat_image_coord (vec3d orig_pos, Calibration *cal, mm_np *mm,
 */
 void img_coord (vec3d pos, Calibration *cal, mm_np *mm, double *x, double *y) {
     flat_image_coord (pos, cal, mm, x, y);
+    *x += cal->int_par.xh;
+    *y += cal->int_par.yh;
     distort_brown_affin (*x, *y, cal->added_par, x, y);
 }
 

--- a/liboptv/tests/check_imgcoord.c
+++ b/liboptv/tests/check_imgcoord.c
@@ -39,6 +39,35 @@ START_TEST(test_flat_centered_cam)
 }
 END_TEST
 
+START_TEST(test_shifted_sensor)
+{
+    /*  When the image plane is centered on the axis. and the camera looks to
+        a straight angle (e.g. along an axis), the image position can be 
+        gleaned from simple geometry.
+    */
+    vec3d pos = {10, 5, -20};
+    Calibration cal = {
+        .ext_par = {0, 0, 40, 0, 0, 0, {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}}},
+        .int_par = {0.1, 0.1, 10},
+        .glass_par = {0, 0, 20},
+        .added_par = {0, 0, 0, 0, 0, 1, 0}
+    };
+    mm_np mm = { /* All in air, simplest case. */
+        .nlay = 1,
+        .n1 = 1,
+        .n2 = {1,0,0},
+        .n3 = 1,
+        .d = {1,0,0},
+        .lut = 1
+    };
+    double x, y; /* Output variables */
+    
+    img_coord(pos, &cal, &mm, &x, &y);
+    fail_unless(x == 10./6. + 0.1);
+    fail_unless(x == 2*(y - 0.1) + 0.1);
+}
+END_TEST
+
 START_TEST(test_flat_decentered_cam)
 {
     /*  When the camera axis goes through the origin, the image point is (0, 0)
@@ -150,6 +179,10 @@ Suite* fb_suite(void) {
     
     tc = tcase_create ("Distorted image coordinates");
     tcase_add_test(tc, test_distorted_centered_cam);
+    suite_add_tcase (s, tc);
+    
+    tc = tcase_create ("Shifted sensor not ignored");
+    tcase_add_test(tc, test_shifted_sensor);
     suite_add_tcase (s, tc);
     return s;
 }


### PR DESCRIPTION
The original img_coord also corrected for the sensor shift. The reimplemented version using flat_image_coord and distort_brown_affin forgot this little difference. The tests didn't catch this because none of them had a shifted sensor. This PR fixes the bug.