### PR TITLE
Fix order of variables in target detection parameters

### DIFF
--- a/liboptv/src/parameters.c
+++ b/liboptv/src/parameters.c
@@ -463,19 +463,11 @@ target_par* read_target_par(char *filename) {
     target_par *ret;
     ret = malloc(sizeof(target_par));
 
-    int discont;
-    int gvthres[4];
-    int nnmin, nnmax;
-    int nxmin, nxmax;
-    int nymin, nymax;
-    int sumg_min;
-    int cr_sz;
-
-    if (   !(fscanf(file, "%d", &ret->discont)==1)      /* max discontinuity */
-        || !(fscanf(file, "%d", &ret->gvthres[0])==1)   /* threshold for binarization 1.image */
+    if (   !(fscanf(file, "%d", &ret->gvthres[0])==1)   /* threshold for binarization 1.image */
         || !(fscanf(file, "%d", &ret->gvthres[1])==1)   /* threshold for binarization 2.image */
         || !(fscanf(file, "%d", &ret->gvthres[2])==1)   /* threshold for binarization 3.image */
         || !(fscanf(file, "%d", &ret->gvthres[3])==1)   /* threshold for binarization 4.image */
+        || !(fscanf(file, "%d", &ret->discont)==1)      /* max discontinuity */
         || !(fscanf(file, "%d  %d", &ret->nnmin, &ret->nnmax)==2) /* min. and max. number of */
         || !(fscanf(file, "%d  %d", &ret->nxmin, &ret->nxmax)==2) /* pixels per target,  */
         || !(fscanf(file, "%d  %d", &ret->nymin, &ret->nymax)==2) /* abs, in x, in y     */
@@ -522,11 +514,11 @@ void write_target_par(target_par *targ, char *filename) {
         printf("Can't create file: %s\n", filename);
 
     fprintf(file, "%d\n%d\n%d\n%d\n%d\n%d\n%d\n%d\n%d\n%d\n%d\n%d\n%d",
-            targ->discont,
             targ->gvthres[0],
             targ->gvthres[1],
             targ->gvthres[2],
             targ->gvthres[3],
+            targ->discont,
             targ->nnmin,
             targ->nnmax,
             targ->nxmin,

--- a/liboptv/tests/check_parameters.c
+++ b/liboptv/tests/check_parameters.c
@@ -11,13 +11,19 @@ START_TEST(test_read_write_compare_targ_rec_par)
     filename_read[]  = "testing_fodder/parameters/targ_rec_all_different_fields.par",
     filename_write[] = "testing_fodder/parameters/targ_out_read.par";
 
-    target_par targ_correct= { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+    target_par targ_correct= { 
+        .gvthres = {1, 2, 3, 4}, 
+        .discont = 5,
+        .nnmin = 6, .nnmax = 7,
+        .nxmin = 8, .nxmax = 9,
+        .nymin = 10, .nymax = 11, 
+        .sumg_min = 12, 
+        .cr_sz = 13 };
+    
     target_par *targ_read = read_target_par(filename_read);
-
     fail_unless(compare_target_par(&targ_correct, targ_read));
 
     write_target_par(targ_read, filename_write);
-
     fail_unless(compare_target_par(&targ_correct, read_target_par(filename_write)));
 
     remove(filename_write);


### PR DESCRIPTION
The previously accepted code works as is, but ios incompatible with the 3D-PTV format, Since basically the only reason we bother with this line-based format is backward compatibility, I hereby fix the order.