### PR TITLE
memory management of parameters bindings

### DIFF
--- a/py_bind/optv/parameters.pyx
+++ b/py_bind/optv/parameters.pyx
@@ -86,19 +86,18 @@ cdef class MultimediaParams:
     def set_n1(self, n1):
         self._mm_np[0].n1 = n1
         
-    # get n2 as numpy array
-    # Parameters: copy (optional) - choose true for returned numpy object to 
-    # take ownership of the memory of the n2 field of the underlying mm_np struct. 
-    # 
-    # PLEASE NOTE: by default, the returned numpy array is a new array 
-    # containing COPIED values from MultimediaParams' underlying mm_np struct.
-    # 
-    # if you want the returned numpy array to take ownership of memory of 
-    # MultimediaParams' mm_np struct and affect it directly, change the value 
-    # of the optional parameter 'copy' to False
     def get_n2(self, copy=True):
+        """
+        get the mid-layer refractive indices (n2) as a numpy array
+        
+        Arguments: 
+        copy - False for returned numpy object to take ownership of 
+            the memory of the n2 field of the underlying mm_np struct. True
+            (default) to return a COPY instead.
+        """
         arr_size = sizeof(self._mm_np[0].n2) / sizeof(self._mm_np[0].n2[0])
-        return wrap_1d_c_arr_as_ndarray(self, arr_size , numpy.NPY_DOUBLE, self._mm_np[0].n2, copy)
+        return wrap_1d_c_arr_as_ndarray(self, arr_size, numpy.NPY_DOUBLE, 
+            self._mm_np[0].n2, copy)
     
     def set_n2(self, n2):
         for i in range(len(n2)):

--- a/py_bind/test/test_parameters_bindings.py
+++ b/py_bind/test/test_parameters_bindings.py
@@ -18,12 +18,12 @@ class Test_MultimediaParams(unittest.TestCase):
         
         self.failUnlessEqual(m.__str__(), "nlay=\t3 \nn1=\t2.0 \nn2=\t{11.0, 22.0, 33.0} \nd=\t{55.0, 66.0, 77.0} \nn3=\t4.0 \nlut=\t1 ")
         
-        arr=m.get_n2(copy=False) # don't copy the values: link directly to memory 
-        arr[0]=77.77
-        arr[1]=88.88
-        arr[2]=99.99
+        arr = m.get_n2(copy=False) # don't copy the values: link directly to memory 
+        arr[0] = 77.77
+        arr[1] = 88.88
+        arr[2] = 99.99
         # assert that the arr affected the contents of m object
-        numpy.testing.assert_array_equal(m.get_n2(), [77.77,88.88,99.99])
+        numpy.testing.assert_array_equal(m.get_n2(), [77.77, 88.88, 99.99])
 
 class Test_TrackingParams(unittest.TestCase):
     


### PR DESCRIPTION
Use numpy arrays in returning array types from the parameter bindings. Care is taken to distinguish a copy from a view, as in numpy. Default is to create a copy.