### PR TITLE
Move vector cross to vec_utils. The norm part is never used nowadays …

### DIFF
--- a/liboptv/include/vec_utils.h
+++ b/liboptv/include/vec_utils.h
@@ -22,6 +22,7 @@ void vec_scalar_mul(vec3d vec, double scalar, vec3d output);
 double vec_norm(vec3d vec);
 double vec_diff_norm(vec3d vec1, vec3d vec2);
 double vec_dot(vec3d vec1, vec3d vec2);
+void vec_cross(vec3d vec1, vec3d vec2, vec3d out);
 int vec_cmp(vec3d vec1, vec3d vec2);
 int vec_approx_cmp(vec3d vec1, vec3d vec2, double eps);
 void unit_vector(vec3d vec, vec3d out);

--- a/liboptv/src/lsqadj.c
+++ b/liboptv/src/lsqadj.c
@@ -155,32 +155,3 @@ for (i=0; i<k; i++) {
   }
 }
 
-
-/* Cross product of two vectors of 3 x 1 
-* Arguments
-* a - vector of doubles 3x1
-* b - vector of doubles 3x1
-* n - output, vector of doubles 3x1
-*/
-
-void norm_cross(double a[3], double b[3], double n[3]) {
-
-    double dummy, rnorm;
-    vec3d res;
-
-    res[0]=a[1]*b[2]-a[2]*b[1];
-    res[1]=a[2]*b[0]-a[0]*b[2];
-    res[2]=a[0]*b[1]-a[1]*b[0];
-    
-    rnorm = vec_norm(res);
-    
-    if (rnorm == 0.0){ // avoids zero length vector bug
-        n[0] = res[0];
-        n[1] = res[0];
-        n[2] = res[0];
-    } else {    
-    n[0]=res[0]/rnorm;
-    n[1]=res[1]/rnorm;
-    n[2]=res[2]/rnorm;
-    }
-}

--- a/liboptv/src/vec_utils.c
+++ b/liboptv/src/vec_utils.c
@@ -113,6 +113,18 @@ double vec_dot(vec3d vec1, vec3d vec2) {
     return sum;
 }
 
+/*  vec_cross() calculates the cross product of two vectors.
+    
+    Arguments:
+    vec3d vec1, vec2 - the vectors whose cross product is sought.
+    vec3d out - output buffer for the result vector.
+*/
+void vec_cross(vec3d vec1, vec3d vec2, vec3d out) {
+    out[0] = vec1[1]*vec2[2] - vec1[2]*vec2[1];
+    out[1] = vec1[2]*vec2[0] - vec1[0]*vec2[2];
+    out[2] = vec1[0]*vec2[1] - vec1[1]*vec2[0];
+}
+
 /*  vec_cmp() checks whether two vectors are equal.
     
     Arguments:

--- a/liboptv/tests/check_lsqadj.c
+++ b/liboptv/tests/check_lsqadj.c
@@ -10,49 +10,6 @@
 
 #define EPS 1E-5
 
-
-START_TEST(test_norm_cross)
-{
-
-    double n[3];
-
-    // test simple cross-product normalized to unity
-
-    double a[] = {1.0, 0.0, 0.0};
-    double b[] = {0.0, 2.0, 0.0};
-
-    norm_cross(a,b,n);
-    fail_unless( (n[0] == 0.0) && (n[1] == 0.0) && (n[2] == 1.0));
-
-
-    // test negative values in the output
-
-    norm_cross(b,a,n);
-    // fail_unless( (n[0] == 0.0) && (n[1] == 0.0) && (n[2] == -1.0));
-
-
-    ck_assert_msg( fabs(n[0] - 0.0) < EPS && 
-                   fabs(n[1] - 0.0) < EPS && 
-                   fabs(n[2] - -1.0)  < EPS,
-             "Was expecting n to be 0., 0., -1. but found %f %f %f\n", n[0],n[1],n[2]);
-         
-
-    // our norm_cross had a bug when multiplying the parallel vectors
-    // it was returning nan instead of 0.0
-    // fixed Aug. 3, 2013, see in ray_tracing.c
-
-    norm_cross(a,a,n);
-    // fail_unless( (n[0] == 0.0) && (n[1] == 0.0) && (n[2] == 0.0));
-
-    ck_assert_msg( fabs(n[0] - 0.0) < EPS && 
-                   fabs(n[1] - 0.0) < EPS && 
-                   fabs(n[2] - 0.0)  < EPS,
-             "Was expecting n to be 0., 0., 0. but found %f %f %f\n", n[0],n[1],n[2]);
-
-
-}
-END_TEST
-
 START_TEST(test_matmul)
 {
 
@@ -174,7 +131,6 @@ Suite* fb_suite(void) {
     Suite *s = suite_create ("lsqadj");
  
     TCase *tc = tcase_create ("lsadj test");
-    tcase_add_test(tc, test_norm_cross);
     tcase_add_test(tc, test_matmul);
     tcase_add_test(tc, test_ata);
     tcase_add_test(tc, test_atl);

--- a/liboptv/tests/check_vec_utils.c
+++ b/liboptv/tests/check_vec_utils.c
@@ -126,6 +126,20 @@ START_TEST(test_unit_vec)
 }
 END_TEST
 
+START_TEST(test_cross)
+{
+    vec3d v1 = {1., 0., 0.}, v2 = {0., 1., 0.}, res = {0., 0., 1.}, out;
+    
+    vec_cross(v1, v2, out);
+    fail_unless(vec_cmp(out, res));
+    
+    /* parallel vectors cross = 0 */
+    res[2] = 0;
+    vec_cross(v1, v1, out);
+    fail_unless(vec_cmp(out, res));
+}
+END_TEST
+
 Suite* fb_suite(void) {
     Suite *s = suite_create ("lsqadj");
  
@@ -167,6 +181,10 @@ Suite* fb_suite(void) {
     
     tc = tcase_create("Add vectors");
     tcase_add_test(tc, test_vec_add);
+    suite_add_tcase (s, tc);
+
+    tc = tcase_create("Cross product");
+    tcase_add_test(tc, test_cross);
     suite_add_tcase (s, tc);
 
     return s;


### PR DESCRIPTION
…but if anyone misses it there's always vec_norm()