### PR TITLE
Fix mmlut bugs

### DIFF
--- a/liboptv/src/multimed.c
+++ b/liboptv/src/multimed.c
@@ -69,7 +69,6 @@ double multimed_r_nlay (Calibration *cal, mm_np *mm, vec3d pos) {
     /* interpolation using the existing mmlut */
 	if (cal->mmlut.data != NULL) {
         mmf = get_mmf_from_mmlut(cal, pos);
-        printf("mmf %g\n", mmf);
         if (mmf > 0) return (mmf);
     }
     

--- a/liboptv/src/multimed.c
+++ b/liboptv/src/multimed.c
@@ -228,7 +228,10 @@ void init_mmlut (volume_par *vpar, control_par *cpar, Calibration *cal) {
   vec3d pos, a, xyz, xyz_t; 
   double x,y, *Ri,*Zi, *data;
   double rw = 2.0; 
-  Exterior Ex_t; /* A frame representing a point outside tank, middle of glass*/
+
+  /* A frame representing a point outside tank, middle of glass*/
+  Calibration cal_t;
+
   double X_t,Y_t,Z_t, Zmin_t,Zmax_t;
   double cross_p[3],cross_c[3]; 
   double xc[2], yc[2];  /* image corners */
@@ -252,6 +255,7 @@ void init_mmlut (volume_par *vpar, control_par *cpar, Calibration *cal) {
   Zmax_t=Zmax;
 
   /* intersect with image vertices rays */
+  cal_t = *cal;
 
   for (i = 0; i < 2; i ++) {
       for (j = 0; j < 2; j++) {
@@ -265,23 +269,23 @@ void init_mmlut (volume_par *vpar, control_par *cpar, Calibration *cal) {
           
           move_along_ray(Zmin, pos, a, xyz);
           trans_Cam_Point(cal->ext_par, *(cpar->mm), cal->glass_par, xyz, \
-            &Ex_t, xyz_t, (double *)cross_p, (double *)cross_c);
+            &(cal_t.ext_par), xyz_t, (double *)cross_p, (double *)cross_c);
 
           if( xyz_t[2] < Zmin_t ) Zmin_t = xyz_t[2];
           if( xyz_t[2] > Zmax_t ) Zmax_t = xyz_t[2];
 
-          R = norm((xyz_t[0] - Ex_t.x0), (xyz_t[1] - Ex_t.y0), 0);
+          R = norm((xyz_t[0] - cal_t.ext_par.x0), (xyz_t[1] - cal_t.ext_par.y0), 0);
           if (R > Rmax)
               Rmax = R;
            
           move_along_ray(Zmax, pos, a, xyz);
           trans_Cam_Point(cal->ext_par, *(cpar->mm), cal->glass_par, xyz,\
-              &Ex_t, xyz_t, (double *)cross_p, (double *)cross_c);
+              &(cal_t.ext_par), xyz_t, (double *)cross_p, (double *)cross_c);
   
           if( xyz_t[2] < Zmin_t ) Zmin_t = xyz_t[2];
           if( xyz_t[2] > Zmax_t ) Zmax_t = xyz_t[2];
 
-          R = norm((xyz_t[0] - Ex_t.x0), (xyz_t[1] - Ex_t.y0), 0);
+          R = norm((xyz_t[0] - cal_t.ext_par.x0), (xyz_t[1] - cal_t.ext_par.y0), 0);
           if (R > Rmax)
               Rmax = R;
       }
@@ -295,7 +299,7 @@ void init_mmlut (volume_par *vpar, control_par *cpar, Calibration *cal) {
   nz = (int)((Zmax_t-Zmin_t)/rw + 1);
 
   /* create two dimensional mmlut structure */
-  vec_set(cal->mmlut.origin, Ex_t.x0, Ex_t.y0, Zmin_t);
+  vec_set(cal->mmlut.origin, cal_t.ext_par.x0, cal_t.ext_par.y0, Zmin_t);
   
   cal->mmlut.nr = nr;
   cal->mmlut.nz = nz;
@@ -315,8 +319,8 @@ void init_mmlut (volume_par *vpar, control_par *cpar, Calibration *cal) {
 
       for (i = 0; i < nr; i++) {
         for (j = 0; j < nz; j++) {
-            vec_set(xyz, Ri[i] + Ex_t.x0, Ex_t.y0, Zi[j]);
-            data[i*nz + j] = multimed_r_nlay(cal, cpar->mm, xyz);
+            vec_set(xyz, Ri[i] + cal_t.ext_par.x0, cal_t.ext_par.y0, Zi[j]);
+            data[i*nz + j] = multimed_r_nlay(&cal_t, cpar->mm, xyz);
         } /* nr */
       } /* nz */
     

--- a/liboptv/src/multimed.c
+++ b/liboptv/src/multimed.c
@@ -69,6 +69,7 @@ double multimed_r_nlay (Calibration *cal, mm_np *mm, vec3d pos) {
     /* interpolation using the existing mmlut */
 	if (cal->mmlut.data != NULL) {
         mmf = get_mmf_from_mmlut(cal, pos);
+        printf("mmf %g\n", mmf);
         if (mmf > 0) return (mmf);
     }
     
@@ -225,7 +226,7 @@ void init_mmlut (volume_par *vpar, control_par *cpar, Calibration *cal) {
   int  i_cam;
   double X,Y,Z, R, Zmin, Rmax=0, Zmax;
   vec3d pos, a, xyz, xyz_t; 
-  double x,y, *Ri,*Zi;
+  double x,y, *Ri,*Zi, *data;
   double rw = 2.0; 
   Exterior Ex_t; /* A frame representing a point outside tank, middle of glass*/
   double X_t,Y_t,Z_t, Zmin_t,Zmax_t;
@@ -301,7 +302,7 @@ void init_mmlut (volume_par *vpar, control_par *cpar, Calibration *cal) {
   cal->mmlut.rw = rw;
   
   if (cal->mmlut.data == NULL) {
-      cal->mmlut.data = (double *) malloc (nr*nz * sizeof (double));
+      data = (double *) malloc (nr*nz * sizeof (double));
   
       /* fill mmlut structure */
       Ri = (double *) malloc (nr * sizeof (double));
@@ -315,12 +316,13 @@ void init_mmlut (volume_par *vpar, control_par *cpar, Calibration *cal) {
       for (i = 0; i < nr; i++) {
         for (j = 0; j < nz; j++) {
             vec_set(xyz, Ri[i] + Ex_t.x0, Ex_t.y0, Zi[j]);
-            cal->mmlut.data[i*nz + j] = multimed_r_nlay(cal, cpar->mm, xyz);
+            data[i*nz + j] = multimed_r_nlay(cal, cpar->mm, xyz);
         } /* nr */
       } /* nz */
     
       free (Ri);
       free (Zi);
+      cal->mmlut.data = data;
     }
 }
 

--- a/liboptv/tests/check_multimed.c
+++ b/liboptv/tests/check_multimed.c
@@ -60,15 +60,22 @@ START_TEST(test_init_mmLUT)
     cpar->num_cams = 1;
              
     init_mmlut (vpar, cpar, cal);
+    
+    /* Data[0] Is the radial shift of a point directly on the glass vector */
+    fail_unless(cal->mmlut.data[0] == 1);
+    
+    /* Radial shift grows with radius */
+    fail_unless(cal->mmlut.data[0] < cal->mmlut.data[correct_mmlut[0].nz]);
+    fail_unless(
+        cal->mmlut.data[correct_mmlut[0].nz] < cal->mmlut.data[2*correct_mmlut[0].nz]);
+    
     ck_assert_msg( 
         fabs(cal->mmlut.origin[0] - correct_mmlut[0].origin[0]) < EPS &&
         fabs(cal->mmlut.origin[1]- correct_mmlut[0].origin[1]) < EPS && 
         fabs(cal->mmlut.origin[2] - correct_mmlut[0].origin[2])  < EPS &&
         cal->mmlut.nr == correct_mmlut[i].nr &&
         cal->mmlut.nz == correct_mmlut[i].nz &&
-        cal->mmlut.rw ==  correct_mmlut[i].rw &&
-        fabs(cal->mmlut.data[0] - 1.11089711) < EPS &&
-        fabs(cal->mmlut.data[200] - 1.09709147) < EPS,
+        cal->mmlut.rw ==  correct_mmlut[i].rw,
         "\n Expected different correct_mmlut values but found: \n \
         x,y,z = %10.8f %10.8f %10.8f \n nr,nz,rw = %d %d %d \n data = %10.8f %10.8f \
          in camera %d \n", 
@@ -222,25 +229,10 @@ START_TEST(test_get_mmf_mmLUT)
     correct_mmlut[0].rw = 2;
     
     init_mmlut (vpar, cpar, cal);
-     
-    ck_assert_msg( 
-        fabs(cal->mmlut.origin[0] - correct_mmlut[0].origin[0]) < EPS && 
-        fabs(cal->mmlut.origin[1] - correct_mmlut[0].origin[1]) < EPS && 
-        fabs(cal->mmlut.origin[2] - correct_mmlut[0].origin[2])  < EPS &&
-        cal->mmlut.nr == correct_mmlut[0].nr &&
-        cal->mmlut.nz == correct_mmlut[0].nz &&
-        cal->mmlut.rw ==  correct_mmlut[0].rw &&
-        fabs(cal->mmlut.data[0] - 1.11089711) < EPS &&
-        fabs(cal->mmlut.data[200] - 1.09709147) < EPS,
-        "\n Expected different correct_mmlut values but found: \n \
-        x,y,z = %10.8f %10.8f %10.8f \n nr,nz,rw = %d %d %d \n data = %10.8f %10.8f\n",
-        cal->mmlut.origin[0], cal->mmlut.origin[1], cal->mmlut.origin[2], \
-        cal->mmlut.nr, cal->mmlut.nz, cal->mmlut.rw, cal->mmlut.data[0], 
-        cal->mmlut.data[200]); 
     
     vec3d pos = {1.0, 1.0, 1.0}; 
     mmf = get_mmf_from_mmlut (cal, pos);
-    ck_assert_msg(fabs(mmf - 1.00363015) < EPS,
+    ck_assert_msg(fabs(mmf - 1.00382) < EPS,
         "\n Expected mmf  1.00363015 but found %10.8f\n", mmf);
 }
 END_TEST
@@ -275,23 +267,13 @@ START_TEST(test_multimed_nlay)
     
     cpar->num_cams = 1; // only one camera test
 
-    mmlut correct_mmlut[4];  
-     
-    vec_set(correct_mmlut[0].origin, 0.0, 0.0, -250.00003540);
-    
-    correct_mmlut[0].nr = 114;
-    correct_mmlut[0].nz = 177;
-    correct_mmlut[0].rw = 2;
-             
     init_mmlut (vpar, cpar, cal);
      
     vec3d pos = {1.23, 1.23, 1.23};
     double correct_Xq,correct_Yq, Xq, Yq;
-    correct_Xq = 0.85954957; 
-    correct_Yq = 0.86851375;   
+    correct_Xq = 0.74811917; 
+    correct_Yq = 0.75977975;   
      
-    i_cam = 0;
-                 
     multimed_nlay(cal, cpar->mm, pos, &Xq, &Yq);
         
     for (i=0; i < cpar->num_cams; i++){


### PR DESCRIPTION
1. The test passsed because of clean allocations which are not guarrantied in actual usage and indeed gave errors.
2. We are again bitten by using regression tests instead of actual tests - the mmlut generated was wrong because of using a wrong origin point for multimed_r_nlay in init_mmlut, but was considered right by thge tester. I fixed it only for the init_mmlut test, other regression test are left as are for now due to time constraints.