### PR TITLE
Fix unfair rejection of images with over 9999 targets.

### DIFF
--- a/liboptv/src/tracking_frame_buf.c
+++ b/liboptv/src/tracking_frame_buf.c
@@ -64,7 +64,7 @@ int read_targets(target buffer[], char* file_base, int frame_num) {
         goto handle_error;
     }
     for (tix = 0; tix < num_targets; tix++)	{
-	  scanf_ok = fscanf (FILEIN, "%4d %lf %lf %d %d %d %d %d\n",
+	  scanf_ok = fscanf (FILEIN, "%d %lf %lf %d %d %d %d %d\n",
 		  &(buffer[tix].pnr),  &(buffer[tix].x),
 		  &(buffer[tix].y),    &(buffer[tix].n),
 		  &(buffer[tix].nx),   &(buffer[tix].ny),


### PR DESCRIPTION
No need to limit the format string here. Probably got copy-pasted somewhen in history and left like this until now. But it trips real cases.