### PR TITLE
Put some order into the 2D coordinates transformations.

### DIFF
--- a/liboptv/include/trafo.h
+++ b/liboptv/include/trafo.h
@@ -48,6 +48,21 @@ void distort_brown_affin (double x
                         , double *x1
                         , double *y1);
 
+void correct_brown_affine_exact(double x, double y, ap_52 ap, 
+    double *x1, double *y1, double tol);
+
+void flat_to_dist(double flat_x, double flat_y, Calibration *cal, 
+    double *dist_x, double *dist_y);
+void dist_to_flat(double dist_x, double dist_y, Calibration *cal,
+    double *flat_x, double *flat_y, double tol);
+
+/* For testing only, please don't use these directly. */
+void old_pixel_to_metric (double *x_metric, double *y_metric, double x_pixel,
+    double y_pixel,int im_size_x, int im_size_y, double pix_size_x, 
+    double pix_size_y, int y_remap_mode);
+void old_metric_to_pixel (double * x_pixel, double * y_pixel, double x_metric,
+    double y_metric, int im_size_x, int im_size_y, double pix_size_x,
+    double pix_size_y, int y_remap_mode);
 
 #endif
 

--- a/liboptv/src/imgcoord.c
+++ b/liboptv/src/imgcoord.c
@@ -8,6 +8,7 @@
 
 #include "imgcoord.h"
 #include "multimed.h"
+#include "trafo.h"
 #include <math.h>
 
 /* flat_image_coord() calculates projection from coordinates in
@@ -69,8 +70,6 @@ void flat_image_coord (vec3d orig_pos, Calibration *cal, mm_np *mm,
 */
 void img_coord (vec3d pos, Calibration *cal, mm_np *mm, double *x, double *y) {
     flat_image_coord (pos, cal, mm, x, y);
-    *x += cal->int_par.xh;
-    *y += cal->int_par.yh;
-    distort_brown_affin (*x, *y, cal->added_par, x, y);
+    flat_to_dist(*x, *y, cal, x, y);
 }
 

--- a/liboptv/src/imgcoord.c
+++ b/liboptv/src/imgcoord.c
@@ -21,7 +21,7 @@
     mm_np *mm - layer thickness and refractive index parameters.
     
     Output:
-    double x,y - pixel coordinates of projection in the image space.
+    double x,y - metric coordinates of projection in the image space.
  */
 void flat_image_coord (vec3d orig_pos, Calibration *cal, mm_np *mm, 
     double *x, double *y)
@@ -66,7 +66,7 @@ void flat_image_coord (vec3d orig_pos, Calibration *cal, mm_np *mm,
     mm_np *mm - layer thickness and refractive index parameters.
     
     Output:
-    double x,y - pixel coordinates of projection in the image space.
+    double x,y - metric distorted coordinates of projection in the image space.
 */
 void img_coord (vec3d pos, Calibration *cal, mm_np *mm, double *x, double *y) {
     flat_image_coord (pos, cal, mm, x, y);

--- a/liboptv/src/orientation.c
+++ b/liboptv/src/orientation.c
@@ -74,8 +74,8 @@ double skew_midpoint(vec3d vert1, vec3d direct1, vec3d vert2, vec3d direct2,
     sent toward it from cameras through the image projections of the point.
 
     Arguments:
-    vec2d targets[] - for each camera, the 2D metric coordinates of the
-        identified point projection.
+    vec2d targets[] - for each camera, the 2D metric, flat, centred coordinates 
+        of the identified point projection.
     int num_cams - number of cameras ( = number of elements in ``targets``).
     mm_np *multimed_pars - multimedia parameters struct for ray tracing through
         several layers.
@@ -94,7 +94,6 @@ double point_position(vec2d targets[], int num_cams, mm_np *multimed_pars,
     double dtot = 0;
     vec3d point_tot = {0., 0., 0.};
 
-    vec2d current;
     vec3d* vertices = (vec3d *) calloc(num_cams, sizeof(vec3d));
     vec3d* directs = (vec3d *) calloc(num_cams, sizeof(vec3d));
     vec3d point;
@@ -102,11 +101,8 @@ double point_position(vec2d targets[], int num_cams, mm_np *multimed_pars,
     /* Shoot rays from all cameras. */
     for (cam = 0; cam < num_cams; cam++) {
         if (targets[cam][0] != PT_UNUSED) {
-            current[0] = targets[cam][0] - cals[cam]->int_par.xh;
-            current[1] = targets[cam][1] - cals[cam]->int_par.yh;
-
-            ray_tracing(current[0], current[1], cals[cam], *multimed_pars,
-                vertices[cam], directs[cam]);
+            ray_tracing(targets[cam][0], targets[cam][1], cals[cam], 
+                *multimed_pars, vertices[cam], directs[cam]);
         }
     }
 
@@ -137,8 +133,8 @@ double point_position(vec2d targets[], int num_cams, mm_np *multimed_pars,
 
     Arguments:
     (vec2d **) targets - 2D array of targets, so order 3 tensor of shape
-        (num_targs,num_cams,2). Each target is the 2D metric coordinates of
-        one identified point.
+        (num_targs,num_cams,2). Each target is the 2D metrici, flat, centred
+        coordinates of one identified point.
     int num_targs - the number of known targets, assumed to be the same in all
         cameras.
     int num_cams - number of cameras.

--- a/liboptv/src/orientation.c
+++ b/liboptv/src/orientation.c
@@ -133,7 +133,7 @@ double point_position(vec2d targets[], int num_cams, mm_np *multimed_pars,
 
     Arguments:
     (vec2d **) targets - 2D array of targets, so order 3 tensor of shape
-        (num_targs,num_cams,2). Each target is the 2D metrici, flat, centred
+        (num_targs,num_cams,2). Each target is the 2D metric, flat, centred
         coordinates of one identified point.
     int num_targs - the number of known targets, assumed to be the same in all
         cameras.

--- a/liboptv/src/trafo.c
+++ b/liboptv/src/trafo.c
@@ -225,6 +225,12 @@ void correct_brown_affine_exact(double x, double y, ap_52 ap,
             - yq * (ap.k1*r*r + ap.k2*r*r*r*r + ap.k3*r*r*r*r*r*r)
             - ap.p2 * (r*r + 2*yq*yq) - 2*ap.p1*xq*yq;
         rq = sqrt (xq*xq + yq*yq);
+        
+        /* Limit divergent iteration. I realize these are "magic values" here
+           but they should work in most cases and trying to automatically find
+           non-magic values will slow this down considerably. 
+        */
+        if (rq > 1.2*r) rq = 0.5*r;
     } while (fabs(rq - r)/r > tol);
     
     /* Final step uses the iteratively-found R and x, y to apply the exact

--- a/liboptv/src/trafo.c
+++ b/liboptv/src/trafo.c
@@ -18,8 +18,6 @@ References:
 /* for the correction routine: */
 #include <math.h>
 
-void old_metric_to_pixel();
-
 /*  old_pixel_to_metric() converts pixel coordinates to metric coordinates
     
     Arguments:

--- a/liboptv/src/trafo.c
+++ b/liboptv/src/trafo.c
@@ -208,6 +208,7 @@ void correct_brown_affine_exact(double x, double y, ap_52 ap,
     double *x1, double *y1, double tol)
 {
     double  r, rq, xq, yq;
+    int itnum = 0;
   
     if ((x == 0) && (y == 0)) return;
     
@@ -231,7 +232,9 @@ void correct_brown_affine_exact(double x, double y, ap_52 ap,
            non-magic values will slow this down considerably. 
         */
         if (rq > 1.2*r) rq = 0.5*r;
-    } while (fabs(rq - r)/r > tol);
+        
+        itnum++;
+    } while ((fabs(rq - r)/r > tol) && (itnum < 201));
     
     /* Final step uses the iteratively-found R and x, y to apply the exact
        correction, equivalent to one more iteration. */

--- a/liboptv/tests/check_trafo.c
+++ b/liboptv/tests/check_trafo.c
@@ -304,6 +304,34 @@ START_TEST(radial_distortion_round_trip)
 }
 END_TEST
 
+START_TEST(dist_flat_round_trip)
+{
+    /*  Cheks that the order of operations in converting metric flat image to
+        distorted image coordinates and vice-versa is correct. 
+        
+        Distortion value in this one is kept to a level suitable (marginally)
+        to an Rmax = 10 mm sensor. The allowed round-trip error is adjusted
+        accordingly. Note that the higher the distortion parameter, the worse
+        will the round-trip error be, at least unless we introduce more iteration
+    */
+    double x=1., y=1.;
+    double xres, yres;
+    double iter_eps = 1e-5; 
+    
+    Calibration cal = {
+        .int_par = {1.5, 1.5, 60.},
+        .added_par = {0.0005, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0}
+    };
+    
+    flat_to_dist(x, y, &cal, &xres, &yres);
+    dist_to_flat(xres, yres, &cal, &xres, &yres);
+    
+    ck_assert_msg( fabs(xres - x) < iter_eps &&
+                   fabs(yres - y) < iter_eps,
+         "Expected %f, %f, but got %f %f\n", x, y, xres, yres);
+}
+END_TEST
+
 Suite* fb_suite(void) {
     Suite *s = suite_create ("trafo");
     TCase *tc = tcase_create ("trafo_test");
@@ -315,6 +343,7 @@ Suite* fb_suite(void) {
     tcase_add_test(tc, shear_round_trip);
     tcase_add_test(tc, dummy_distortion_round_trip);
     tcase_add_test(tc, radial_distortion_round_trip);
+    tcase_add_test(tc, dist_flat_round_trip);
     suite_add_tcase (s, tc);   
     return s;
 }

--- a/liboptv/tests/check_trafo.c
+++ b/liboptv/tests/check_trafo.c
@@ -314,7 +314,7 @@ START_TEST(dist_flat_round_trip)
         accordingly. Note that the higher the distortion parameter, the worse
         will the round-trip error be, at least unless we introduce more iteration
     */
-    double x=1., y=1.;
+    double x=10., y=10.;
     double xres, yres;
     double iter_eps = 1e-5; 
     
@@ -324,7 +324,7 @@ START_TEST(dist_flat_round_trip)
     };
     
     flat_to_dist(x, y, &cal, &xres, &yres);
-    dist_to_flat(xres, yres, &cal, &xres, &yres);
+    dist_to_flat(xres, yres, &cal, &xres, &yres, 0.00001);
     
     ck_assert_msg( fabs(xres - x) < iter_eps &&
                    fabs(yres - y) < iter_eps,

--- a/py_bind/optv/transforms.pxd
+++ b/py_bind/optv/transforms.pxd
@@ -1,6 +1,6 @@
 
 from optv.parameters cimport control_par
-from optv.calibration cimport ap_52
+from optv.calibration cimport ap_52, calibration
 
 cdef extern from "optv/trafo.h":
     void pixel_to_metric(double * x_metric
@@ -23,3 +23,11 @@ cdef extern from "optv/trafo.h":
                          , ap_52 ap
                          , double * x1
                          , double * y1);
+    
+    void correct_brown_affine_exact(double x, double y, ap_52 ap, 
+    double *x1, double *y1, double tol)
+    
+    void flat_to_dist(double flat_x, double flat_y, calibration *cal, 
+        double *dist_x, double *dist_y)
+    void dist_to_flat(double dist_x, double dist_y, calibration *cal,
+        double *flat_x, double *flat_y, double tol)


### PR DESCRIPTION
Most important thing is the correct ordering and improvement of the distortion/correction operations.

Some functions which previously assumed metric distorted input but failed to do proper correction now assume corrected input. Since I'm the only one using those in my dumbbell and other calibration codes, I believe this isn't too bad. In the future, calls to det_lsq_3d in openptv-python will have to be replaced carefully to have exactly the right kind of conversion there.