### PR TITLE
Image preprocessing bindings

### DIFF
--- a/liboptv/src/image_processing.c
+++ b/liboptv/src/image_processing.c
@@ -359,7 +359,8 @@ void copy_images (unsigned char *src, unsigned char *dest, control_par *cpar)
    Arguments:
    unsigned char  *img - the source image to filter.
    unsigned char  *img_hp - result buffer for filtered image. Same size as img.
-   int dim_lp - dimension of subtracted lowpass image.
+   int dim_lp - half-width of lowpass filter, see fast_box_blur()'s filt_span
+      parameter.
    int filter_hp - flag for additional filtering of _hp. 1 for lowpass, 2 for 
       general 3x3 filter given in parameter ``filter_file``.
    char *filter_file - path to a text file containing the filter matrix to be

--- a/py_bind/optv/image_processing.pxd
+++ b/py_bind/optv/image_processing.pxd
@@ -1,0 +1,9 @@
+from optv.parameters cimport control_par
+
+cdef extern from "optv/image_processing.h":
+    int prepare_image(unsigned char * img,
+                        unsigned char * img_hp,
+                        int dim_lp,
+                        int filter_hp,
+                        char * filter_file,
+                        control_par * cpar)

--- a/py_bind/optv/image_processing.pyx
+++ b/py_bind/optv/image_processing.pyx
@@ -1,21 +1,20 @@
 from optv.parameters cimport ControlParams, control_par
 import numpy as np
-from twisted.cred import error
 cimport numpy as np
 
-def preprocess_image(np.ndarray[ndim=2, dtype=np.uint8_t] input,
+def preprocess_image(np.ndarray[ndim=2, dtype=np.uint8_t] input_img,
                    int filter_hp,
                    ControlParams control,
-                   int lowpass_dim=0,
+                   int lowpass_dim=1,
                    filter_file=None,
-                   np.ndarray[ndim=2, dtype=np.uint8_t] output=None):
+                   np.ndarray[ndim=2, dtype=np.uint8_t] output_img=None):
     '''
     preprocess_image() - perform the steps necessary for preparing an image to 
     particle detection: an averaging (smoothing) filter on an image, optionally
     followed by additional user-defined filter.
     
     Arguments:
-    numpy.ndarray input - numpy 2d array representing the source image to filter.
+    numpy.ndarray input_img - numpy 2d array representing the source image to filter.
     int filter_hp - flag for additional filtering of _hp. 1 for lowpass, 2 for 
         general 3x3 filter given in parameter ``filter_file``.
     ControlParams control - image details such as size and image half for 
@@ -24,7 +23,7 @@ def preprocess_image(np.ndarray[ndim=2, dtype=np.uint8_t] input,
     filter_file - path to a text file containing the filter matrix to be
         used in case ```filter_hp == 2```. One line per row, white-space 
         separated columns.
-    numpy.ndarray output - result numpy 2d array representing the source 
+    numpy.ndarray output_img - result numpy 2d array representing the source 
         image to filter. Same size as img.
     
     Returns:
@@ -32,13 +31,13 @@ def preprocess_image(np.ndarray[ndim=2, dtype=np.uint8_t] input,
     '''
 
     # check arrays dimensions
-    if input.ndim != 2:
-        raise TypeError("Input matrix must be two-dimensional")
-    if output != None and (input.shape[0] != output.shape[0] or
-                         input.shape[1] != output.shape[1]):
+    if input_img.ndim != 2:
+        raise TypeError("Input array must be two-dimensional")
+    if output_img != None and (input_img.shape[0] != output_img.shape[0] or
+                         input_img.shape[1] != output_img.shape[1]):
         raise ValueError("Different shapes of input and output images.")
     else:
-        output = np.empty_like(input)
+        output_img = np.empty_like(input_img)
     
     if filter_hp == 2:
         if filter_file == None or not isinstance(filter_file, basestring):
@@ -46,16 +45,16 @@ def preprocess_image(np.ndarray[ndim=2, dtype=np.uint8_t] input,
     else:
         filter_file=""
         
-    for arr in (input, output):
+    for arr in (input_img, output_img):
         if not arr.flags['C_CONTIGUOUS']:
             np.ascontiguousarray(arr)
     
-    if (1 != prepare_image( < unsigned char *> input.data,
-                            < unsigned char *> output.data,
+    if (1 != prepare_image( < unsigned char *> input_img.data,
+                            < unsigned char *> output_img.data,
                             lowpass_dim,
                             filter_hp,
                             filter_file,
                             control._control_par)):
         raise Exception("prepare_image C function failed: "
                       + "failure of memory allocation or filter file reading")
-    return output              
+    return output_img              

--- a/py_bind/optv/image_processing.pyx
+++ b/py_bind/optv/image_processing.pyx
@@ -33,7 +33,7 @@ def preprocess_image(np.ndarray[ndim=2, dtype=np.uint8_t] input_img,
     # check arrays dimensions
     if input_img.ndim != 2:
         raise TypeError("Input array must be two-dimensional")
-    if output_img != None and (input_img.shape[0] != output_img.shape[0] or
+    if (output_img is not None) and (input_img.shape[0] != output_img.shape[0] or
                          input_img.shape[1] != output_img.shape[1]):
         raise ValueError("Different shapes of input and output images.")
     else:

--- a/py_bind/optv/image_processing.pyx
+++ b/py_bind/optv/image_processing.pyx
@@ -19,7 +19,8 @@ def preprocess_image(np.ndarray[ndim=2, dtype=np.uint8_t] input_img,
         general 3x3 filter given in parameter ``filter_file``.
     ControlParams control - image details such as size and image half for 
     interlaced cases.
-    int lowpass_dim - dimension of subtracted lowpass image.
+    int lowpass_dim - half-width of lowpass filter, see fast_box_blur()'s filt_span
+      parameter.
     filter_file - path to a text file containing the filter matrix to be
         used in case ```filter_hp == 2```. One line per row, white-space 
         separated columns.

--- a/py_bind/optv/image_processing.pyx
+++ b/py_bind/optv/image_processing.pyx
@@ -1,0 +1,61 @@
+from optv.parameters cimport ControlParams, control_par
+import numpy as np
+from twisted.cred import error
+cimport numpy as np
+
+def preprocess_image(np.ndarray[ndim=2, dtype=np.uint8_t] input,
+                   int filter_hp,
+                   ControlParams control,
+                   int lowpass_dim=0,
+                   filter_file=None,
+                   np.ndarray[ndim=2, dtype=np.uint8_t] output=None):
+    '''
+    preprocess_image() - perform the steps necessary for preparing an image to 
+    particle detection: an averaging (smoothing) filter on an image, optionally
+    followed by additional user-defined filter.
+    
+    Arguments:
+    numpy.ndarray input - numpy 2d array representing the source image to filter.
+    int filter_hp - flag for additional filtering of _hp. 1 for lowpass, 2 for 
+        general 3x3 filter given in parameter ``filter_file``.
+    ControlParams control - image details such as size and image half for 
+    interlaced cases.
+    int lowpass_dim - dimension of subtracted lowpass image.
+    filter_file - path to a text file containing the filter matrix to be
+        used in case ```filter_hp == 2```. One line per row, white-space 
+        separated columns.
+    numpy.ndarray output - result numpy 2d array representing the source 
+        image to filter. Same size as img.
+    
+    Returns:
+    numpy.ndarray representing the result image.
+    '''
+
+    # check arrays dimensions
+    if input.ndim != 2:
+        raise TypeError("Input matrix must be two-dimensional")
+    if output != None and (input.shape[0] != output.shape[0] or
+                         input.shape[1] != output.shape[1]):
+        raise ValueError("Different shapes of input and output images.")
+    else:
+        output = np.empty_like(input)
+    
+    if filter_hp == 2:
+        if filter_file == None or not isinstance(filter_file, basestring):
+            raise ValueError("Expecting a filter file name, received None or non-string.")
+    else:
+        filter_file=""
+        
+    for arr in (input, output):
+        if not arr.flags['C_CONTIGUOUS']:
+            np.ascontiguousarray(arr)
+    
+    if (1 != prepare_image( < unsigned char *> input.data,
+                            < unsigned char *> output.data,
+                            lowpass_dim,
+                            filter_hp,
+                            filter_file,
+                            control._control_par)):
+        raise Exception("prepare_image C function failed: "
+                      + "failure of memory allocation or filter file reading")
+    return output              

--- a/py_bind/setup.py
+++ b/py_bind/setup.py
@@ -17,6 +17,7 @@ ext_mods = [
     mk_ext("optv.calibration", ["optv/calibration.pyx"]),
     mk_ext("optv.transforms", ["optv/transforms.pyx"]),
     mk_ext("optv.imgcoord", ["optv/imgcoord.pyx"])
+    mk_ext("optv.image_processing", ["optv/image_processing.pyx"])
 ]
 
 setup(

--- a/py_bind/setup.py
+++ b/py_bind/setup.py
@@ -16,7 +16,7 @@ ext_mods = [
     mk_ext("optv.parameters", ["optv/parameters.pyx"]),
     mk_ext("optv.calibration", ["optv/calibration.pyx"]),
     mk_ext("optv.transforms", ["optv/transforms.pyx"]),
-    mk_ext("optv.imgcoord", ["optv/imgcoord.pyx"])
+    mk_ext("optv.imgcoord", ["optv/imgcoord.pyx"]),
     mk_ext("optv.image_processing", ["optv/image_processing.pyx"])
 ]
 

--- a/py_bind/test/test_image_processing.py
+++ b/py_bind/test/test_image_processing.py
@@ -2,12 +2,11 @@ import unittest
 from optv.parameters import ControlParams
 from optv.image_processing import preprocess_image
 import numpy as np, os
-from numpy.core.multiarray import dtype
 
 class Test_image_processing(unittest.TestCase):
         
     def setUp(self):
-        self.input = np.array([[ 0, 0, 0, 0, 0],
+        self.input_img = np.array([[ 0, 0, 0, 0, 0],
                                [ 0, 255, 255, 255, 0],
                                [ 0, 255, 255, 255, 0],
                                [ 0, 255, 255, 255, 0],
@@ -18,18 +17,18 @@ class Test_image_processing(unittest.TestCase):
         
     def test_arguments(self):
         with self.assertRaises(ValueError):
-            preprocess_image(self.input, self.filter_hp, self.control,
-                             lowpass_dim=1, output=np.empty((5, 4), dtype=np.uint8))
+            preprocess_image(self.input_img, self.filter_hp, self.control,
+                             lowpass_dim=1, output_img=np.empty((5, 4), dtype=np.uint8))
         
        
         with self.assertRaises(ValueError):
             # 3d output
-            preprocess_image(self.input, self.filter_hp, self.control,
-                             lowpass_dim=1, output=np.empty((5, 5, 5), dtype=np.uint8))
+            preprocess_image(self.input_img, self.filter_hp, self.control,
+                             lowpass_dim=1, output_img=np.empty((5, 5, 5), dtype=np.uint8))
             
         with self.assertRaises(ValueError):
             # filter_hp=2 but filter_file=None
-            preprocess_image(self.input, 2, self.control, output=np.empty((5, 5), dtype=np.uint8))
+            preprocess_image(self.input_img, 2, self.control, output_img=np.empty((5, 5), dtype=np.uint8))
         
     def test_preprocess_image(self):
         correct_res = np.array([[ 0, 0, 0, 0, 0],
@@ -39,17 +38,14 @@ class Test_image_processing(unittest.TestCase):
                                 [ 0, 0, 0, 0, 0]],
                                dtype=np.uint8)
         
-        res = preprocess_image(self.input,
+        res = preprocess_image(self.input_img,
                                self.filter_hp,
                                self.control,
                                lowpass_dim=1,
                                filter_file=None,
-                               output=None)
+                               output_img=None)
         
         np.testing.assert_array_equal(res, correct_res)
 
-    def tearDown(self):
-        pass
-    
 if __name__ == "__main__":
     unittest.main()

--- a/py_bind/test/test_image_processing.py
+++ b/py_bind/test/test_image_processing.py
@@ -1,0 +1,55 @@
+import unittest
+from optv.parameters import ControlParams
+from optv.image_processing import preprocess_image
+import numpy as np, os
+from numpy.core.multiarray import dtype
+
+class Test_image_processing(unittest.TestCase):
+        
+    def setUp(self):
+        self.input = np.array([[ 0, 0, 0, 0, 0],
+                               [ 0, 255, 255, 255, 0],
+                               [ 0, 255, 255, 255, 0],
+                               [ 0, 255, 255, 255, 0],
+                               [ 0, 0, 0, 0, 0]], dtype=np.uint8)
+        self.filter_hp = 0
+        self.control = ControlParams(4)
+        self.control.set_image_size((5, 5))
+        
+    def test_arguments(self):
+        with self.assertRaises(ValueError):
+            preprocess_image(self.input, self.filter_hp, self.control,
+                             lowpass_dim=1, output=np.empty((5, 4), dtype=np.uint8))
+        
+       
+        with self.assertRaises(ValueError):
+            # 3d output
+            preprocess_image(self.input, self.filter_hp, self.control,
+                             lowpass_dim=1, output=np.empty((5, 5, 5), dtype=np.uint8))
+            
+        with self.assertRaises(ValueError):
+            # filter_hp=2 but filter_file=None
+            preprocess_image(self.input, 2, self.control, output=np.empty((5, 5), dtype=np.uint8))
+        
+    def test_preprocess_image(self):
+        correct_res = np.array([[ 0, 0, 0, 0, 0],
+                                [ 0, 142, 85, 142, 0],
+                                [ 0, 85, 0, 85, 0],
+                                [ 0, 142, 85, 142, 0],
+                                [ 0, 0, 0, 0, 0]],
+                               dtype=np.uint8)
+        
+        res = preprocess_image(self.input,
+                               self.filter_hp,
+                               self.control,
+                               lowpass_dim=1,
+                               filter_file=None,
+                               output=None)
+        
+        np.testing.assert_array_equal(res, correct_res)
+
+    def tearDown(self):
+        pass
+    
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Python bindings to the general image preprocessing routine which in the past was called ``highpass()`` and is now called ``prepare_image()`` in liboptv.