### PR TITLE
Fix double free in Python bindings of control/mm parameters

### DIFF
--- a/py_bind/optv/parameters.pyx
+++ b/py_bind/optv/parameters.pyx
@@ -689,7 +689,7 @@ cdef class ControlParams:
         
     def __dealloc__(self):
         # set the mm pointer to NULL in order to prevent c_free_control_par 
-        # function to free it. MultimediaParams object will free this
+        # function from freeing it. MultimediaParams object will free this
         # memory in its python destructor when there will be no references to it.
         
         self._control_par[0].mm = NULL


### PR DESCRIPTION
A one-liner, really. Set a pointer to null because free(NULL) does nothing.