### PR TITLE
Fix segmentation faults

### DIFF
--- a/liboptv/src/CMakeLists.txt
+++ b/liboptv/src/CMakeLists.txt
@@ -19,7 +19,8 @@ add_library (optv SHARED tracking_frame_buf.c calibration.c parameters.c lsqadj.
 
 
 if(UNIX)
-  target_link_libraries(optv m)
+  target_link_libraries(optv m 
+    debug efence)
 endif(UNIX)
 
 install(TARGETS optv DESTINATION lib)

--- a/liboptv/src/segmentation.c
+++ b/liboptv/src/segmentation.c
@@ -16,6 +16,7 @@ Description:
 
 #include "segmentation.h"
 #include <string.h>
+#include <stdio.h>
 
 typedef short targpix[2];
 
@@ -68,6 +69,14 @@ int targ_rec (unsigned char *img, target_par *targ_par, int xmin,
     img0 = (unsigned char *) calloc (imx*imy, 1);
     memcpy(img0, img, imx*imy);
 
+    /* Make sure the min/max coordinates don't cause us to access memory
+       outside the image memory.
+    */
+    if (xmin <= 0) xmin = 1;
+    if (ymin <= 0) ymin = 1;
+    if (xmax >= imx) xmax = imx - 1;
+    if (ymax >= imy) ymax = imy - 1;
+    
     /*  thresholding and connectivity analysis in image  */
     for (i=ymin; i<ymax; i++)  for (j=xmin; j<xmax; j++)
     {
@@ -110,7 +119,8 @@ int targ_rec (unsigned char *img, target_par *targ_par, int xmin,
                     /* conditions for threshold, discontinuity, image borders */
                     /* and peak fitting */
                     if (   (gv > thres)
-                       && (xn>=xmin)&&(xn<xmax) && (yn>=ymin)&&(yn<ymax)
+                       && (xn > xmin - 1) && (xn < xmax + 1) 
+                       && (yn > ymin - 1) && (yn < ymax + 1)
                        && (gv <= gvref+disco)
                        && (gvref + disco >= *(img + imx*(yn-1) + xn))
                        && (gvref + disco >= *(img + imx*(yn+1) + xn))
@@ -148,8 +158,11 @@ int targ_rec (unsigned char *img, target_par *targ_par, int xmin,
             }   /*  end of while-loop  */
 
             /* check whether target touches image borders */
-            if (xa==xmin || ya==ymin || xb==xmax-1 || yb==ymax-1)
+            if (xa == (xmin - 1) || ya == (ymin - 1) || 
+                xb == (xmax + 1)|| yb == (ymax + 1)) 
+            {
                 continue;
+            }
 
             /* get targets extensions in x and y */
             nx = xb - xa + 1;  

--- a/liboptv/tests/check_image_proc.c
+++ b/liboptv/tests/check_image_proc.c
@@ -127,7 +127,7 @@ START_TEST(test_box_blur)
     
     /*  set lowpass edge values to 0 so it equals the no-wrap action of 
         the fast box blur */
-    for (elem = 0; elem < 6; elem++) {
+    for (elem = 0; elem < 5; elem++) {
         img_mean[5*elem] = 0;
         img_mean[5*elem + 4] = 0;
     }

--- a/liboptv/tests/check_segmentation.c
+++ b/liboptv/tests/check_segmentation.c
@@ -87,34 +87,32 @@ START_TEST(test_targ_rec)
         .cr_sz = 13 };
     
                 
-   ntargets = targ_rec (img, &targ_par, 0, cpar.imx, 0, cpar.imy, &cpar, 0, pix);
-   fail_unless(ntargets == 1);
-   fail_unless(pix[0].n == 9);
+    ntargets = targ_rec (img, &targ_par, 0, cpar.imx, 0, cpar.imy, &cpar, 0, pix);
+    fail_unless(ntargets == 1);
+    fail_unless(pix[0].n == 9);
    
-   /* test the two objects */
-     unsigned char img1[5][5] = {
+    /* test the two objects */
+    unsigned char img1[5][5] = {
         { 0,   0,   0,   0, 0},
         { 0, 255, 0, 0, 0},
         { 0, 0, 0, 0, 0},
         { 0, 0, 0, 251, 0},
         { 0,   0,   0,   0, 0}
     };
-   ntargets = targ_rec (img1, &targ_par, 0, cpar.imx, 0, cpar.imy, &cpar, 1, 
+    ntargets = targ_rec (img1, &targ_par, 0, cpar.imx, 0, cpar.imy, &cpar, 1, 
         pix);
-   fail_unless(ntargets == 2);
+    fail_unless(ntargets == 2);
    
-   targ_par.gvthres[1] = 252; 
-   ntargets = targ_rec ((unsigned char *)img1, &targ_par, 0, cpar.imx, 
+    targ_par.gvthres[1] = 252; 
+    ntargets = targ_rec ((unsigned char *)img1, &targ_par, 0, cpar.imx, 
         0, cpar.imy, &cpar, 1, pix);
-   fail_unless(ntargets == 1);
+    fail_unless(ntargets == 1);
 
     /* Trip a segfault writing over the edge. */
-    printf("trying\n");
     img1[4][4] = 255;
     ntargets = targ_rec (img1, &targ_par, 0, cpar.imx, 0, cpar.imy, &cpar, 1,
         pix);
-  /* If execution reached here, test passed. */
-
+    /* If execution reached here, test passed. */
 }
 END_TEST
 

--- a/liboptv/tests/check_segmentation.c
+++ b/liboptv/tests/check_segmentation.c
@@ -111,7 +111,7 @@ START_TEST(test_targ_rec)
     /* Trip a segfault writing over the edge. */
     printf("trying\n");
     img1[4][4] = 255;
-    ntargets = targ_rec (img1, &targ_par, 0, cpar.imx, -1, cpar.imy, &cpar, 1,
+    ntargets = targ_rec (img1, &targ_par, 0, cpar.imx, 0, cpar.imy, &cpar, 1,
         pix);
   /* If execution reached here, test passed. */
 

--- a/liboptv/tests/check_segmentation.c
+++ b/liboptv/tests/check_segmentation.c
@@ -108,6 +108,12 @@ START_TEST(test_targ_rec)
         0, cpar.imy, &cpar, 1, pix);
    fail_unless(ntargets == 1);
 
+    /* Trip a segfault writing over the edge. */
+    printf("trying\n");
+    img1[4][4] = 255;
+    ntargets = targ_rec (img1, &targ_par, 0, cpar.imx, -1, cpar.imy, &cpar, 1,
+        pix);
+  /* If execution reached here, test passed. */
 
 }
 END_TEST


### PR DESCRIPTION
After spending like 2 hours with Lily trying to find why his Mac trips code that works perfectly fine on Linux, we tracked it again to a memory access violation that just didn't cause trouble on Linux and did on Mac.

Beside fixing this one bug, I also used the [Electric Fence](http://elinux.org/Electric_Fence) tool to consistently trip memory access bugs. To use it, pass ``-DCMAKE_BUILD_TYPE=Debug`` to Cmake. The tool links his own memory allocator to the library, so we don't want it in release builds.

So, With this I added a test to trip the bug in segmentation, fixed it, and fixed one more that efence found.