### PR TITLE
Correspondences

### DIFF
--- a/liboptv/include/correspondences.h
+++ b/liboptv/include/correspondences.h
@@ -42,5 +42,4 @@ void qs_con (n_tupel *con, int left, int right);
 
 n_tupel *correspondences (frame *frm, volume_par *vpar, control_par *cpar, 
 Calibration **calib, int match_counts[]);
-
 #endif

--- a/liboptv/include/correspondences.h
+++ b/liboptv/include/correspondences.h
@@ -40,7 +40,7 @@ void quicksort_con (n_tupel	*con, int num);
 void qs_con (n_tupel *con, int left, int right);
 
 
-int correspondences_4 (target pix[][nmax], coord_2d geo[][nmax], int num[],
+int correspondences (target pix[][nmax], coord_2d geo[][nmax], int num[],
     volume_par *vpar, control_par *cpar, Calibration cals[], n_tupel *con, int match_counts[]);
 
 #endif

--- a/liboptv/include/correspondences.h
+++ b/liboptv/include/correspondences.h
@@ -40,7 +40,7 @@ void quicksort_con (n_tupel	*con, int num);
 void qs_con (n_tupel *con, int left, int right);
 
 
-int correspondences (target pix[][nmax], coord_2d geo[][nmax], int num[],
-    volume_par *vpar, control_par *cpar, Calibration cals[], n_tupel *con, int match_counts[]);
+n_tupel *correspondences (frame *frm, volume_par *vpar, control_par *cpar, 
+Calibration **calib, int match_counts[]);
 
 #endif

--- a/liboptv/include/correspondences.h
+++ b/liboptv/include/correspondences.h
@@ -51,6 +51,9 @@ int safely_allocate_adjacency_lists(correspond* lists[4][4], int num_cams,
     int *target_counts);
 void deallocate_adjacency_lists(correspond* lists[4][4], int num_cams);
 
+int four_camera_matching(correspond *list[4][4], int base_target_count, 
+    double accept_corr, n_tupel *scratch, int scratch_size);
+
 void match_pairs(correspond *list[4][4], coord_2d **corrected, 
     frame *frm, volume_par *vpar, control_par *cpar, Calibration **calib);
 

--- a/liboptv/include/correspondences.h
+++ b/liboptv/include/correspondences.h
@@ -46,6 +46,8 @@ n_tupel *correspondences (frame *frm, coord_2d **corrected,
 
 
 /* subcomponents of correspondences, may be separately useful. */
+int** safely_allocate_target_usage_marks(int num_cams);
+void deallocate_target_usage_marks(int** tusage, int num_cams);
 
 int safely_allocate_adjacency_lists(correspond* lists[4][4], int num_cams, 
     int *target_counts);
@@ -53,6 +55,9 @@ void deallocate_adjacency_lists(correspond* lists[4][4], int num_cams);
 
 int four_camera_matching(correspond *list[4][4], int base_target_count, 
     double accept_corr, n_tupel *scratch, int scratch_size);
+int three_camera_matching(correspond *list[4][4], int num_cams, 
+    int *target_counts, double accept_corr, n_tupel *scratch, int scratch_size,
+    int** tusage);
 
 void match_pairs(correspond *list[4][4], coord_2d **corrected, 
     frame *frm, volume_par *vpar, control_par *cpar, Calibration **calib);

--- a/liboptv/include/correspondences.h
+++ b/liboptv/include/correspondences.h
@@ -58,6 +58,9 @@ int four_camera_matching(correspond *list[4][4], int base_target_count,
 int three_camera_matching(correspond *list[4][4], int num_cams, 
     int *target_counts, double accept_corr, n_tupel *scratch, int scratch_size,
     int** tusage);
+int consistent_pair_matching(correspond *list[4][4], int num_cams, 
+    int *target_counts, double accept_corr, n_tupel *scratch, int scratch_size,
+    int** tusage);
 
 void match_pairs(correspond *list[4][4], coord_2d **corrected, 
     frame *frm, volume_par *vpar, control_par *cpar, Calibration **calib);

--- a/liboptv/include/correspondences.h
+++ b/liboptv/include/correspondences.h
@@ -40,8 +40,9 @@ void quicksort_con (n_tupel	*con, int num);
 void qs_con (n_tupel *con, int left, int right);
 
 
-n_tupel *correspondences (frame *frm, volume_par *vpar, control_par *cpar, 
-    Calibration **calib, int match_counts[]);
+n_tupel *correspondences (frame *frm, coord_2d **corrected, 
+    volume_par *vpar, control_par *cpar, Calibration **calib,
+    int match_counts[]);
 
 
 /* subcomponents of correspondences, may be separately useful. */

--- a/liboptv/include/correspondences.h
+++ b/liboptv/include/correspondences.h
@@ -48,6 +48,8 @@ n_tupel *correspondences (frame *frm, volume_par *vpar, control_par *cpar,
 
 int safely_allocate_adjacency_lists(correspond* lists[4][4], int num_cams, 
     int *target_counts);
+void deallocate_adjacency_lists(correspond* lists[4][4], int num_cams);
+
 void match_pairs(correspond *list[4][4], coord_2d **corrected, 
     frame *frm, volume_par *vpar, control_par *cpar, Calibration **calib);
 

--- a/liboptv/include/correspondences.h
+++ b/liboptv/include/correspondences.h
@@ -6,9 +6,33 @@
 #include "tracking_frame_buf.h"
 #include "parameters.h"
 #include "calibration.h"
+#include "epi.h"
+
+#define nmax 202400
+
+
+typedef struct
+{
+  int     p[4];
+  double  corr;
+}
+n_tupel;
+
+
+typedef struct
+{
+  int    	p1;	       	/* point number of master point */
+  int    	n;	       	/* # of candidates */
+  int    	p2[MAXCAND];	/* point numbers of candidates */
+  double	corr[MAXCAND];	/* feature based correlation coefficient */
+  double	dist[MAXCAND];	/* distance perpendicular to epipolar line */
+}
+correspond;	       	/* correspondence candidates */
+
 
 void quicksort_target_y (target *pix, int num);
 void quicksort_coord2d_x (coord_2d *crd, int num);
+void qs_target_y (target *pix, int left, int right);
 int correspondences_4 (target pix[][nmax], coord_2d geo[][nmax], int num[],
     volume_par *vpar, control_par *cpar, Calibration cals[], n_tupel *con, int match_counts[]);
 

--- a/liboptv/include/correspondences.h
+++ b/liboptv/include/correspondences.h
@@ -1,0 +1,15 @@
+/* Header for the old correspondences code. */
+
+#ifndef CORRESPONDENCES_H
+#define CORRESPONDENCES_H
+
+#include "tracking_frame_buf.h"
+#include "parameters.h"
+#include "calibration.h"
+
+void quicksort_target_y (target *pix, int num);
+void quicksort_coord2d_x (coord_2d *crd, int num);
+int correspondences_4 (target pix[][nmax], coord_2d geo[][nmax], int num[],
+    volume_par *vpar, control_par *cpar, Calibration cals[], n_tupel *con, int match_counts[]);
+
+#endif

--- a/liboptv/include/correspondences.h
+++ b/liboptv/include/correspondences.h
@@ -41,5 +41,14 @@ void qs_con (n_tupel *con, int left, int right);
 
 
 n_tupel *correspondences (frame *frm, volume_par *vpar, control_par *cpar, 
-Calibration **calib, int match_counts[]);
+    Calibration **calib, int match_counts[]);
+
+
+/* subcomponents of correspondences, may be separately useful. */
+
+int safely_allocate_adjacency_lists(correspond* lists[4][4], int num_cams, 
+    int *target_counts);
+void match_pairs(correspond *list[4][4], coord_2d **corrected, 
+    frame *frm, volume_par *vpar, control_par *cpar, Calibration **calib);
+
 #endif

--- a/liboptv/include/correspondences.h
+++ b/liboptv/include/correspondences.h
@@ -31,8 +31,15 @@ correspond;	       	/* correspondence candidates */
 
 
 void quicksort_target_y (target *pix, int num);
-void quicksort_coord2d_x (coord_2d *crd, int num);
 void qs_target_y (target *pix, int left, int right);
+
+void quicksort_coord2d_x (coord_2d *crd, int num);
+void qs_coord2d_x (coord_2d	*crd, int left, int right);
+
+void quicksort_con (n_tupel	*con, int num);
+void qs_con (n_tupel *con, int left, int right);
+
+
 int correspondences_4 (target pix[][nmax], coord_2d geo[][nmax], int num[],
     volume_par *vpar, control_par *cpar, Calibration cals[], n_tupel *con, int match_counts[]);
 

--- a/liboptv/include/tracking_frame_buf.h
+++ b/liboptv/include/tracking_frame_buf.h
@@ -12,6 +12,8 @@ for all cameras, correspondence information and path links information.
 #define POSI 80
 #define STR_MAX_LEN 255
 
+#define PT_UNUSED -999
+
 typedef struct
 {
   int     pnr;

--- a/liboptv/src/CMakeLists.txt
+++ b/liboptv/src/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 
 include_directories("../include/")
 
-add_library (optv SHARED tracking_frame_buf.c calibration.c parameters.c lsqadj.c ray_tracing.c trafo.c vec_utils.c image_processing.c multimed.c imgcoord.c epi.c orientation.c sortgrid.c segmentation.c)
+add_library (optv SHARED tracking_frame_buf.c calibration.c parameters.c lsqadj.c ray_tracing.c trafo.c vec_utils.c image_processing.c multimed.c imgcoord.c epi.c orientation.c sortgrid.c segmentation.c correspondences.c)
 
 
 

--- a/liboptv/src/correspondences.c
+++ b/liboptv/src/correspondences.c
@@ -153,7 +153,7 @@ void qs_coord2d_x (coord_2d	*crd, int left, int right){
 /*--------------- 4 camera model: consistent quadruplets -------------------*/
 /****************************************************************************/
 
-int correspondences_4 (target pix[][nmax], coord_2d geo[][nmax], int num[], 
+int correspondences (target pix[][nmax], coord_2d geo[][nmax], int num[], 
     volume_par *vpar, control_par *cpar, Calibration cals[], n_tupel *con, 
     int match_counts[])
 {

--- a/liboptv/src/correspondences.c
+++ b/liboptv/src/correspondences.c
@@ -527,9 +527,9 @@ Calibration **calib, int match_counts[]) {
 // 
 //   ----------------------------------------------------------------------- */
 //   free memory for lists of correspondences */
-//   for (i1 = 0; i1 < cpar->num_cams - 1; i1++)
-//     for (i2 = i1 + 1; i2 < cpar->num_cams; i2++)
-//         free (list[i1][i2]);
+  for (i1 = 0; i1 < cpar->num_cams - 1; i1++)
+    for (i2 = i1 + 1; i2 < cpar->num_cams; i2++)
+        free (list[i1][i2]);
 
   free (con0);
 

--- a/liboptv/src/correspondences.c
+++ b/liboptv/src/correspondences.c
@@ -172,14 +172,15 @@ Calibration **calib, int match_counts[]) {
   double img_x, img_y; /* image center */
   
 
+
   /* allocate memory for lists of correspondences */
   for (i1 = 0; i1 < cpar->num_cams - 1; i1++)
     for (i2 = i1 + 1; i2 < cpar->num_cams; i2++)
        list[i1][i2] = (correspond *) malloc (frm->num_targets[i1] * sizeof (correspond));
 
-   con0 = (n_tupel *) calloc(cpar->num_cams, sizeof(n_tupel));
-   con = (n_tupel *) calloc(cpar->num_cams, sizeof(n_tupel));
-  
+  con0 = (n_tupel *) calloc(cpar->num_cams, sizeof(n_tupel));
+  con = (n_tupel *) calloc(cpar->num_cams, sizeof(n_tupel));
+
   for (i1 = 0; i1 < cpar->num_cams - 1; i1++)
     for (i2 = i1 + 1; i2 < cpar->num_cams; i2++)
       for (i=0; i<frm->num_targets[i1]; i++)
@@ -187,8 +188,13 @@ Calibration **calib, int match_counts[]) {
 	  list[i1][i2][i].p1 = 0;
 	  list[i1][i2][i].n = 0;
 	}
-    	
-  for (i = 0; i < nmax; i++) {
+
+/* if I understand correctly, the number of matches cannot be more than the number of
+   targets (dots) in the first image. In the future we'll replace it by the maximum
+   number of targets in any image (if we will implement the cyclic search) but for 
+   a while we always start with the cam1
+*/     	
+  for (i = 0; i < frm->num_targets[0]; i++) {
     for (j = 0; j < cpar->num_cams; j++) {
         tim[j][i] = 0;
         con0[i].p[j] = -1;
@@ -196,342 +202,329 @@ Calibration **calib, int match_counts[]) {
     con0[i].corr = 0.0;
   }
   
-  printf("finished allocating before corrected\n");
 
-//     We work on distortion-corrected image coordinates of particles.
-//        This loop does the correction. It also recycles the iteration on
-//        frm->num_cams to allocate some arrays needed later and do some related
-//        preparation. */
-//     corrected = (coord_2d **) malloc(frm->num_cams * sizeof(coord_2d *));
-//     for (cam = 0; cam < frm->num_cams; cam++) {
-//         corrected[cam] = (coord_2d *) malloc(
-//             frm->num_targets[cam] * sizeof(coord_2d));
-//             
-//         for (part = 0; part < frm->num_targets[cam]; part++) {
-//             pixel_to_metric(&corrected[cam][part].x, 
-//                             &corrected[cam][part].y,
-//                             frm->targets[cam][part].x, 
-//                             frm->targets[cam][part].y,
-//                             cpar);
-//             
-//             img_x = corrected[cam][part].x - calib[cam]->int_par.xh;
-//             img_y = corrected[cam][part].y - calib[cam]->int_par.yh;
-//             
-//             correct_brown_affin (img_x, img_y, calib[cam]->added_par,
-//                &corrected[cam][part].x, &corrected[cam][part].y);
-//             
-//             corrected[cam][part].pnr = frm->targets[cam][part].pnr;
-//         }
-//         
-//         This is expected by find_candidate_plus() */
-//         quicksort_coord2d_x(corrected[cam], frm->num_targets[cam]);
-//     }
-// 
-// 
-// 
-//   matching  1 -> 2,3,4  +  2 -> 3,4  +  3 -> 4 */
-//   for (i1 = 0; i1 < cpar->num_cams - 1; i1++)
-//     for (i2 = i1 + 1; i2 < cpar->num_cams; i2++) {
-// 
-//       for (i=0; i<frm->num_targets[i1]; i++)	if (corrected[i1][i].x != -999) {
-//           epi_mm (corrected[i1][i].x, corrected[i1][i].y, calib[i1], calib[i2], 
-//           cpar->mm, vpar, &xa12, &ya12, &xb12, &yb12);
-// 	  
-// 	  origin point in the list */
-// 	  p1 = i;  list[i1][i2][p1].p1 = p1;	pt1 = corrected[i1][p1].pnr;
-// 
-// 	  search for a conjugate point in corrected[i2] */
-//       count = find_candidate (corrected[i2], frm->targets[i2], frm->num_targets[i2],
-//             xa12, ya12, xb12, yb12, 
-//             frm->targets[i1][pt1].n,frm->targets[i1][pt1].nx,frm->targets[i1][pt1].ny,
-//             frm->targets[i1][pt1].sumg, cand, vpar, cpar, calib[i2] );
-//             
-// 	  write all corresponding candidates to the preliminary list */
-// 	  of correspondences */
-// 	  if (count > MAXCAND)	{ count = MAXCAND; }
-// 	  for (j=0; j<count; j++)
-// 	    {
-// 	      list[i1][i2][p1].p2[j] = cand[j].pnr;
-// 	      list[i1][i2][p1].corr[j] = cand[j].corr;
-// 	      list[i1][i2][p1].dist[j] = cand[j].tol;
-// 	    }
-// 	  list[i1][i2][p1].n = count;
-// 	}
-//   }
-//   
-//     Image coordinates not needed beyond this point. */
-//     for (cam = 0; cam < frm->num_cams; cam++) {
-//         free(corrected[cam]);
-//     }
-//     free(corrected);
-// 
-// 
-//   ------------------------------------------------------------------ */
-//   search consistent quadruplets in the list */
-//   if (cpar->num_cams == 4) {
-//       for (i=0, match0=0; i<frm->num_targets[0]; i++)
-// 	{
-// 	  p1 = list[0][1][i].p1;
-// 	  for (j=0; j<list[0][1][i].n; j++)
-// 	    for (k=0; k<list[0][2][i].n; k++)
-// 	      for (l=0; l<list[0][3][i].n; l++)
-// 		{
-// 		  p2 = list[0][1][i].p2[j];
-// 		  p3 = list[0][2][i].p2[k];
-// 		  p4 = list[0][3][i].p2[l];
-// 		  for (m=0; m<list[1][2][p2].n; m++) {
-// 			p31 = list[1][2][p2].p2[m];
-//             if (p3 != p31) continue;
-// 		    for (n=0; n<list[1][3][p2].n; n++)
-// 		      {
-// 			p41 = list[1][3][p2].p2[n];
-// 			if (p4 != p41) continue;
-//               i3 = list[2][3][p3].n;
-// 			  for (o=0; o<i3; o++)
-// 			    {
-// 			      p42 = list[2][3][p3].p2[o];
-// 			      if (p4 == p42)
-// 				{
-// 				  corr = (list[0][1][i].corr[j]
-// 					  + list[0][2][i].corr[k]
-// 					  + list[0][3][i].corr[l]
-// 					  + list[1][2][p2].corr[m]
-// 					  + list[1][3][p2].corr[n]
-// 					  + list[2][3][p3].corr[o])
-// 				    / (list[0][1][i].dist[j]
-// 				       + list[0][2][i].dist[k]
-// 				       + list[0][3][i].dist[l]
-// 				       + list[1][2][p2].dist[m]
-// 				       + list[1][3][p2].dist[n]
-// 				       + list[2][3][p3].dist[o]);
-// 				  if (corr > vpar->corrmin)
-// 				    {
-// 				      accept as preliminary match */
-// 				      con0[match0].p[0] = p1;
-// 				      con0[match0].p[1] = p2;
-// 				      con0[match0].p[2] = p3;
-// 				      con0[match0].p[3] = p4;
-// 				      con0[match0++].corr = corr;
-// 				      if (match0 == 4*nmax)	/* security */
-// 					{
-// 					  printf ("Overflow in correspondences:");
-// 					  printf (" > %d matches\n", match0);
-// 					  i = frm->num_targets[0];
-// 					}
-// 				    }
-// 				}
-// 			    }
-//               
-// 		      }
-//             }
-// 		}
-// 	}
-// 
-// 
-//       -------------------------------------------------------------------- */
-// 
-//       sort quadruplets for match quality (.corr) */
-//       quicksort_con (con0, match0);
-// 
-//       -------------------------------------------------------------------- */
-// 
-//       take quadruplets from the top to the bottom of the sorted list */
-//       only if none of the points has already been used */
-//       for (i=0, match=0; i<match0; i++)
-// 	{
-// 	  p1 = con0[i].p[0];	if (p1 > -1)	if (++tim[0][p1] > 1)	continue;
-// 	  p2 = con0[i].p[1];	if (p2 > -1)	if (++tim[1][p2] > 1)	continue;
-// 	  p3 = con0[i].p[2];	if (p3 > -1)	if (++tim[2][p3] > 1)	continue;
-// 	  p4 = con0[i].p[3];	if (p4 > -1)	if (++tim[3][p4] > 1)	continue;
-// 	  con[match++] = con0[i];
-// 	}
-// 
-//       match4 = match;
-//     }
-// 
-//   ----------------------------------------------------------------------- */
-//   ----------------------------------------------------------------------- */
-// 
-//   search consistent triplets :  123, 124, 134, 234 */
-//   if ((cpar->num_cams == 4 && cpar->allCam_flag == 0) || cpar->num_cams == 3)
-//     {
-//       //printf("Search consistent triplets \n");
-//       match0 = 0;
-//       for (i1 = 0; i1 < cpar->num_cams - 2; i1++)
-//         for (i2 = i1 + 1; i2 < cpar->num_cams - 1; i2++)
-//            for (i3 = i2 + 1; i3 < cpar->num_cams; i3++)
-// 				for (i=0; i<frm->num_targets[i1]; i++){
-// 					 p1 = list[i1][i2][i].p1;
-// 					 if (p1 > nmax  ||  tim[i1][p1] > 0)	continue;
-// 
-// 					 for (j=0; j<list[i1][i2][i].n; j++)
-// 					  for (k=0; k<list[i1][i3][i].n; k++) {
-// 						  p2 = list[i1][i2][i].p2[j];
-// 						  if (p2 > nmax  ||  tim[i2][p2] > 0)	continue;
-// 						  p3 = list[i1][i3][i].p2[k];
-// 						  if (p3 > nmax  ||  tim[i3][p3] > 0)	continue;
-// 						  						  
-// 						  for (m=0; m<list[i2][i3][p2].n; m++) {
-// 						     p31 = list[i2][i3][p2].p2[m];
-// 						     
-// 						     if (p3 == p31) {
-// 							    corr = (list[i1][i2][i].corr[j]
-// 								  + list[i1][i3][i].corr[k]
-// 								  + list[i2][i3][p2].corr[m])
-// 							    / (list[i1][i2][i].dist[j]
-// 							    + list[i1][i3][i].dist[k]
-// 							    + list[i2][i3][p2].dist[m]);
-// 							  if (corr > vpar->corrmin) {
-// 								for (n = 0; n < cpar->num_cams; n++) con0[match0].p[n] = -2;
-// 									con0[match0].p[i1] = p1;
-// 									con0[match0].p[i2] = p2;
-// 									con0[match0].p[i3] = p3;
-// 									con0[match0++].corr = corr;
-// 								}
-// 								if (match0 == 4*nmax) {   /* security */
-// 									printf ("Overflow in correspondences:\n");
-// 									printf (" > %d matches\n", match0);
-// 									i = frm->num_targets[i1]; /* Break out of the outer loop over i */
-// 								}
-// 							}
-// 						  }
-// 					    }
-// 					}
-// 
-//       ----------------------------------------------------------------------- */
-// 
-//       sort triplets for match quality (.corr) */
-//       quicksort_con (con0, match0);
-// 
-//       ----------------------------------------------------------------------- */
-// 
-//       pragmatic version: */
-//       take triplets from the top to the bottom of the sorted list */
-//       only if none of the points has already been used */
-//       for (i=0; i<match0; i++){
-// 		  p1 = con0[i].p[0];	if (p1 > -1)	if (++tim[0][p1] > 1)	continue;
-// 		  p2 = con0[i].p[1];	if (p2 > -1)	if (++tim[1][p2] > 1)	continue;
-// 		  p3 = con0[i].p[2];	if (p3 > -1)	if (++tim[2][p3] > 1)	continue;
-// 		  p4 = con0[i].p[3];	if (p4 > -1  && cpar->num_cams > 3) if (++tim[3][p4] > 1) continue;
-// 
-// 		  con[match] = con0[i];
-// 		  match++;
-// 	  }
-// 
-//       match3 = match - match4;
-// 
-//       repair artifact (?) */
-//       if (cpar->num_cams == 3) for (i=0; i<match; i++)	con[i].p[3] = -1;
-//     }
-// 
-//   ----------------------------------------------------------------------- */
-//   ----------------------------------------------------------------------- */
-// 
-//   search consistent pairs :  12, 13, 14, 23, 24, 34 */
-//   only if an object model is available or if only 2 images are used */
-//       if(cpar->num_cams > 1 && cpar->allCam_flag == 0){
-// 		  match0 = 0;
-// 		  for (i1 = 0; i1 < cpar->num_cams - 1; i1++)
-// 			if ( cpar->num_cams == 2 || (frm->num_targets[0] < 64 && 
-// 			frm->num_targets[1] < 64 && frm->num_targets[2] < 64 && 
-// 			frm->num_targets[3] < 64))
-// 			  for (i2 = i1 + 1; i2 < cpar->num_cams; i2++)
-// 			for (i=0; i<frm->num_targets[i1]; i++)
-// 			  {
-// 				p1 = list[i1][i2][i].p1;
-// 				if (p1 > nmax  ||  tim[i1][p1] > 0)	continue;
-// 
-// 				take only unambigous pairs */
-// 				if (list[i1][i2][i].n != 1)	continue;
-// 
-// 				p2 = list[i1][i2][i].p2[0];
-// 				if (p2 > nmax  ||  tim[i2][p2] > 0)	continue;
-// 
-// 				corr = list[i1][i2][i].corr[0] / list[i1][i2][i].dist[0];
-// 
-// 				if (corr > vpar->corrmin)
-// 				  {
-// 				con0[match0].p[i1] = p1;
-// 				con0[match0].p[i2] = p2;
-// 				con0[match0++].corr = corr;
-// 				  }
-// 			  }
-// 
-// 		  ----------------------------------------------------------------------- */
-// 
-// 
-// 		  sort pairs for match quality (.corr) */
-// 		  quicksort_con (con0, match0);
-// 
-// 		  ----------------------------------------------------------------------- */
-// 
-// 
-// 		  take pairs from the top to the bottom of the sorted list */
-// 		  only if none of the points has already been used */
-// 		  for (i=0; i<match0; i++) {
-// 			  p1 = con0[i].p[0];	if (p1 > -1)	if (++tim[0][p1] > 1)	continue;
-// 			  p2 = con0[i].p[1];	if (p2 > -1)	if (++tim[1][p2] > 1)	continue;
-// 			  p3 = con0[i].p[2];	if (p3 > -1  && cpar->num_cams > 2)
-// 			  if (++tim[2][p3] > 1)	continue;
-// 			  p4 = con0[i].p[3];	if (p4 > -1  && cpar->num_cams > 3)
-// 			  if (++tim[3][p4] > 1)	continue;
-// 
-// 			  con[match++] = con0[i];
-// 			}
-// 		  } //end pairs?
-// 
-//      match2 = match-match4-match3;
-//     if(cpar->num_cams == 1){
-//        printf ( "determined %d points from 2D", match1);
-//        }
-//      else{
-//       printf ("%d quadruplets (red), %d triplets (green) and %d unambigous pairs\n",
-// 	      match4, match3, match2);
-//      }
-//   ----------------------------------------------------------------------- */
-// 
-//   give each used pix the correspondence number */
-//   for (i=0; i<match; i++)
-//     {
-//       for (j = 0; j < cpar->num_cams; j++)
-//         {
-//          Skip cameras without a correspondence obviously. */
-//          if (con[i].p[j] < 0) continue;
-// 
-// 	     p1 = corrected[j][con[i].p[j]].pnr;
-// 	     if (p1 > -1 && p1 < 1202590843)
-// 	      {
-// 	        frm->targets[j][p1].tnr= i;
-// 	      }
-// 	    }
-//     }
-// 
-//     int count1=0;
-// 	j=0;
-// 	
-// 	for (i=0; i < frm->num_targets[j]; i++)
-// 	  {			      	
-// 	    p1 = frm->targets[j][i].tnr;
-// 	    if (p1 == -1 )
-// 	      {
-// 		   count1++;
-// 	      }
-// 	  }
-//     printf("unidentified objects = %d\n",count1);
-// 
-// Retun values: match counts of each clique size */
-//     match_counts[0] = match4;
-//     match_counts[1] = match3;
-//     match_counts[2] = match2;
-//     match_counts[3] = match;
-// 
-//   ----------------------------------------------------------------------- */
-//   free memory for lists of correspondences */
+/*  We work on distortion-corrected image coordinates of particles.
+        This loop does the correction. It also recycles the iteration on
+        frm->num_cams to allocate some arrays needed later and do some related
+        preparation. 
+*/
+
+    printf("num cams = %d or %d\n", cpar->num_cams, frm->num_cams);
+    
+    corrected = (coord_2d **) malloc(frm->num_cams * sizeof(coord_2d *));
+    for (cam = 0; cam < cpar->num_cams; cam++) {
+        corrected[cam] = (coord_2d *) malloc(
+            frm->num_targets[cam] * sizeof(coord_2d));
+            
+        for (part = 0; part < frm->num_targets[cam]; part++) {
+            pixel_to_metric(&corrected[cam][part].x, 
+                            &corrected[cam][part].y,
+                            frm->targets[cam][part].x, 
+                            frm->targets[cam][part].y,
+                            cpar);
+                            
+            //printf("%f %f \n", frm->targets[cam][part].x, frm->targets[cam][part].y);                
+            //printf("%f %f \n", corrected[cam][part].x, corrected[cam][part].y);
+            
+            img_x = corrected[cam][part].x - calib[cam]->int_par.xh;
+            img_y = corrected[cam][part].y - calib[cam]->int_par.yh;
+            
+            correct_brown_affin (img_x, img_y, calib[cam]->added_par,
+               &corrected[cam][part].x, &corrected[cam][part].y);
+            
+            corrected[cam][part].pnr = frm->targets[cam][part].pnr;
+            
+            // printf('%f %f %d \n', corrected[cam][part].x, corrected[cam][part].y, corrected[cam][part].pnr);
+            //printf("%f %f %d \n", corrected[cam][part].x, corrected[cam][part].y, corrected[cam][part].pnr);
+        }
+        
+        /* This is expected by find_candidate_plus() */
+        quicksort_coord2d_x(corrected[cam], frm->num_targets[cam]);
+    }
+ 
+/*   matching  1 -> 2,3,4  +  2 -> 3,4  +  3 -> 4 */
+  for (i1 = 0; i1 < cpar->num_cams - 1; i1++)
+    for (i2 = i1 + 1; i2 < cpar->num_cams; i2++) {
+
+      for (i=0; i<frm->num_targets[i1]; i++)	if (corrected[i1][i].x != -999) {
+          epi_mm (corrected[i1][i].x, corrected[i1][i].y, calib[i1], calib[i2], 
+          cpar->mm, vpar, &xa12, &ya12, &xb12, &yb12);
+          
+          // printf('%f %f\n', corrected[i1][i].x, corrected[i1][i].y);
+          // printf('%f %f %f %f\n', xa12, ya12, xb12, yb12);
+          
+	  
+          /* origin point in the list */
+	      p1 = i;  list[i1][i2][p1].p1 = p1;	pt1 = corrected[i1][p1].pnr;
+
+           /* search for a conjugate point in corrected[i2] */
+            count = find_candidate (corrected[i2], frm->targets[i2], frm->num_targets[i2],
+            xa12, ya12, xb12, yb12, 
+            frm->targets[i1][pt1].n,frm->targets[i1][pt1].nx,frm->targets[i1][pt1].ny,
+            frm->targets[i1][pt1].sumg, cand, vpar, cpar, calib[i2]);
+             
+/* 	         write all corresponding candidates to the preliminary list 
+ 	          of correspondences */
+	  if (count > MAXCAND)	{ count = MAXCAND; }
+	  for (j=0; j<count; j++)
+	    {
+	      list[i1][i2][p1].p2[j] = cand[j].pnr;
+	      list[i1][i2][p1].corr[j] = cand[j].corr;
+	      list[i1][i2][p1].dist[j] = cand[j].tol;
+	    }
+	  list[i1][i2][p1].n = count;
+	}
+  }
+  
+    /* Image coordinates not needed beyond this point. */
+    for (cam = 0; cam < frm->num_cams; cam++) {
+        free(corrected[cam]);
+    }
+    free(corrected);
+
+/*   search consistent quadruplets in the list */
+  if (cpar->num_cams == 4) {
+      for (i=0, match0=0; i<frm->num_targets[0]; i++)
+	{
+	  p1 = list[0][1][i].p1;
+	  for (j=0; j<list[0][1][i].n; j++)
+	    for (k=0; k<list[0][2][i].n; k++)
+	      for (l=0; l<list[0][3][i].n; l++)
+		{
+		  p2 = list[0][1][i].p2[j];
+		  p3 = list[0][2][i].p2[k];
+		  p4 = list[0][3][i].p2[l];
+		  for (m=0; m<list[1][2][p2].n; m++) {
+			p31 = list[1][2][p2].p2[m];
+            if (p3 != p31) continue;
+		    for (n=0; n<list[1][3][p2].n; n++)
+		      {
+			p41 = list[1][3][p2].p2[n];
+			if (p4 != p41) continue;
+              i3 = list[2][3][p3].n;
+			  for (o=0; o<i3; o++)
+			    {
+			      p42 = list[2][3][p3].p2[o];
+			      if (p4 == p42)
+				{
+				  corr = (list[0][1][i].corr[j]
+					  + list[0][2][i].corr[k]
+					  + list[0][3][i].corr[l]
+					  + list[1][2][p2].corr[m]
+					  + list[1][3][p2].corr[n]
+					  + list[2][3][p3].corr[o])
+				    / (list[0][1][i].dist[j]
+				       + list[0][2][i].dist[k]
+				       + list[0][3][i].dist[l]
+				       + list[1][2][p2].dist[m]
+				       + list[1][3][p2].dist[n]
+				       + list[2][3][p3].dist[o]);
+				  if (corr > vpar->corrmin)
+				    {
+				      /*accept as preliminary match */
+				      con0[match0].p[0] = p1;
+				      con0[match0].p[1] = p2;
+				      con0[match0].p[2] = p3;
+				      con0[match0].p[3] = p4;
+				      con0[match0++].corr = corr;
+				      if (match0 == 4*nmax)	/* security */
+					{
+					  printf ("Overflow in correspondences:");
+					  printf (" > %d matches\n", match0);
+					  i = frm->num_targets[0];
+					}
+				    }
+				}
+			    }
+              
+		      }
+            }
+		}
+	}
+
+/*       sort quadruplets for match quality (.corr) */
+        quicksort_con (con0, match0);
+
+/*       take quadruplets from the top to the bottom of the sorted list
+       only if none of the points has already been used */
+      for (i=0, match=0; i<match0; i++)
+	{
+	  p1 = con0[i].p[0];	if (p1 > -1)	if (++tim[0][p1] > 1)	continue;
+	  p2 = con0[i].p[1];	if (p2 > -1)	if (++tim[1][p2] > 1)	continue;
+	  p3 = con0[i].p[2];	if (p3 > -1)	if (++tim[2][p3] > 1)	continue;
+	  p4 = con0[i].p[3];	if (p4 > -1)	if (++tim[3][p4] > 1)	continue;
+	  con[match++] = con0[i];
+	}
+ 
+       match4 = match;
+     }
+
+/*   search consistent triplets :  123, 124, 134, 234 */
+  if ((cpar->num_cams == 4 && cpar->allCam_flag == 0) || cpar->num_cams == 3)
+    {
+      //printf("Search consistent triplets \n");
+      match0 = 0;
+      for (i1 = 0; i1 < cpar->num_cams - 2; i1++)
+        for (i2 = i1 + 1; i2 < cpar->num_cams - 1; i2++)
+           for (i3 = i2 + 1; i3 < cpar->num_cams; i3++)
+				for (i=0; i<frm->num_targets[i1]; i++){
+					 p1 = list[i1][i2][i].p1;
+					 if (p1 > nmax  ||  tim[i1][p1] > 0)	continue;
+
+					 for (j=0; j<list[i1][i2][i].n; j++)
+					  for (k=0; k<list[i1][i3][i].n; k++) {
+						  p2 = list[i1][i2][i].p2[j];
+						  if (p2 > nmax  ||  tim[i2][p2] > 0)	continue;
+						  p3 = list[i1][i3][i].p2[k];
+						  if (p3 > nmax  ||  tim[i3][p3] > 0)	continue;
+						  						  
+						  for (m=0; m<list[i2][i3][p2].n; m++) {
+						     p31 = list[i2][i3][p2].p2[m];
+						     
+						     if (p3 == p31) {
+							    corr = (list[i1][i2][i].corr[j]
+								  + list[i1][i3][i].corr[k]
+								  + list[i2][i3][p2].corr[m])
+							    / (list[i1][i2][i].dist[j]
+							    + list[i1][i3][i].dist[k]
+							    + list[i2][i3][p2].dist[m]);
+							  if (corr > vpar->corrmin) {
+								for (n = 0; n < cpar->num_cams; n++) con0[match0].p[n] = -2;
+									con0[match0].p[i1] = p1;
+									con0[match0].p[i2] = p2;
+									con0[match0].p[i3] = p3;
+									con0[match0++].corr = corr;
+								}
+								if (match0 == 4*nmax) {   /* security */
+									printf ("Overflow in correspondences:\n");
+									printf (" > %d matches\n", match0);
+									i = frm->num_targets[i1]; /* Break out of the outer loop over i */
+								}
+							}
+						  }
+					    }
+					}
+/*       sort triplets for match quality (.corr) */
+       quicksort_con (con0, match0);
+
+/*     pragmatic version: 
+       take triplets from the top to the bottom of the sorted list 
+       only if none of the points has already been used 
+*/
+      for (i=0; i<match0; i++){
+		  p1 = con0[i].p[0];	if (p1 > -1)	if (++tim[0][p1] > 1)	continue;
+		  p2 = con0[i].p[1];	if (p2 > -1)	if (++tim[1][p2] > 1)	continue;
+		  p3 = con0[i].p[2];	if (p3 > -1)	if (++tim[2][p3] > 1)	continue;
+		  p4 = con0[i].p[3];	if (p4 > -1  && cpar->num_cams > 3) if (++tim[3][p4] > 1) continue;
+
+		  con[match] = con0[i];
+		  match++;
+	  }
+
+      match3 = match - match4;
+
+      /* repair artifact (?) */
+      if (cpar->num_cams == 3) for (i=0; i<match; i++)	con[i].p[3] = -1;
+    }
+  
+/*   search consistent pairs :  12, 13, 14, 23, 24, 34 
+      only if an object model is available or if only 2 images are used 
+*/
+      if(cpar->num_cams > 1 && cpar->allCam_flag == 0){
+		  match0 = 0;
+		  for (i1 = 0; i1 < cpar->num_cams - 1; i1++)
+			if ( cpar->num_cams == 2 || (frm->num_targets[0] < 64 && 
+			frm->num_targets[1] < 64 && frm->num_targets[2] < 64 && 
+			frm->num_targets[3] < 64))
+			  for (i2 = i1 + 1; i2 < cpar->num_cams; i2++)
+			for (i=0; i<frm->num_targets[i1]; i++)
+			  {
+				p1 = list[i1][i2][i].p1;
+				if (p1 > nmax  ||  tim[i1][p1] > 0)	continue;
+
+				/* take only unambigous pairs */
+				if (list[i1][i2][i].n != 1)	continue;
+
+				p2 = list[i1][i2][i].p2[0];
+				if (p2 > nmax  ||  tim[i2][p2] > 0)	continue;
+
+				corr = list[i1][i2][i].corr[0] / list[i1][i2][i].dist[0];
+
+				if (corr > vpar->corrmin)
+				  {
+				con0[match0].p[i1] = p1;
+				con0[match0].p[i2] = p2;
+				con0[match0++].corr = corr;
+				  }
+			  }
+
+/* 		  sort pairs for match quality (.corr) */
+ 		  quicksort_con (con0, match0);
+
+/* 		  take pairs from the top to the bottom of the sorted list 
+ 		  only if none of the points has already been used 
+*/
+		  for (i=0; i<match0; i++) {
+			  p1 = con0[i].p[0];	if (p1 > -1)	if (++tim[0][p1] > 1)	continue;
+			  p2 = con0[i].p[1];	if (p2 > -1)	if (++tim[1][p2] > 1)	continue;
+			  p3 = con0[i].p[2];	if (p3 > -1  && cpar->num_cams > 2)
+			  if (++tim[2][p3] > 1)	continue;
+			  p4 = con0[i].p[3];	if (p4 > -1  && cpar->num_cams > 3)
+			  if (++tim[3][p4] > 1)	continue;
+
+			  con[match++] = con0[i];
+			}
+		  } 
+ 
+      match2 = match-match4-match3;
+    if(cpar->num_cams == 1){
+       printf ( "determined %d points from 2D", match1);
+       }
+     else{
+      printf ("%d quadruplets (red), %d triplets (green) and %d unambigous pairs\n",
+	      match4, match3, match2);
+     }
+/*   give each used pix the correspondence number */
+  for (i=0; i<match; i++)
+    {
+      for (j = 0; j < cpar->num_cams; j++)
+        {
+         /* Skip cameras without a correspondence obviously. */
+         if (con[i].p[j] < 0) continue;
+
+	     p1 = corrected[j][con[i].p[j]].pnr;
+	     if (p1 > -1 && p1 < 1202590843)
+	      {
+	        frm->targets[j][p1].tnr= i;
+	      }
+	    }
+    }
+
+    int count1=0;
+	j=0;
+	
+	for (i=0; i < frm->num_targets[j]; i++)
+	  {			      	
+	    p1 = frm->targets[j][i].tnr;
+	    if (p1 == -1 )
+	      {
+		   count1++;
+	      }
+	  }
+    printf("unidentified objects = %d\n",count1);
+
+/* Retun values: match counts of each clique size */
+    match_counts[0] = match4;
+    match_counts[1] = match3;
+    match_counts[2] = match2;
+    match_counts[3] = match;
+
+/*   free memory for lists of correspondences */
   for (i1 = 0; i1 < cpar->num_cams - 1; i1++)
     for (i2 = i1 + 1; i2 < cpar->num_cams; i2++)
-        free (list[i1][i2]);
+          free (list[i1][i2]);
 
-  free (con0);
+   free (con0);
 
   return con;
 }

--- a/liboptv/src/correspondences.c
+++ b/liboptv/src/correspondences.c
@@ -4,7 +4,7 @@ Routine:	       	correspondences.c
 
 Author/Copyright:      	Hans-Gerd Maas
 
-Address:	      	Institute of Geodesy and Photogrammetry
+Address:	      	Institute of correcteddesy and Photogrammetry
 	      		ETH - Hoenggerberg
 	      		CH - 8093 Zurich
 
@@ -14,7 +14,7 @@ Description:	       	establishment of correspondences for 2/3/4 cameras
 
 ****************************************************************************/
 
-
+#include <stdio.h>
 #include "correspondences.h"
 
 
@@ -153,11 +153,12 @@ void qs_coord2d_x (coord_2d	*crd, int left, int right){
 /*--------------- 4 camera model: consistent quadruplets -------------------*/
 /****************************************************************************/
 
-int correspondences (target pix[][nmax], coord_2d geo[][nmax], int num[], 
-    volume_par *vpar, control_par *cpar, Calibration cals[], n_tupel *con, 
-    int match_counts[])
-{
-  int 	i,j,k,l,m,n,o,  i1,i2,i3;
+// int correspondences (target pix[][nmax], coord_2d corrected[][nmax], int num[], 
+//     volume_par *vpar, control_par *cpar, Calibration calib[], n_tupel *con, 
+//     int match_counts[]){
+n_tupel *correspondences (frame *frm, volume_par *vpar, control_par *cpar, 
+Calibration **calib, int match_counts[]) {
+  int 	i,j,k,l,m,n,o,i1,i2,i3,cam,part;
   int   count, match=0, match0=0, match4=0, match3=0, match2=0, match1=0;
   int 	p1,p2,p3,p4, p31, p41, p42;
   int  	pt1;
@@ -165,329 +166,373 @@ int correspondences (target pix[][nmax], coord_2d geo[][nmax], int num[],
   double       	xa12,ya12,xb12,yb12,X,Y,Z;
   double       	corr;
   candidate   	cand[MAXCAND];
-  n_tupel     	*con0;
+  n_tupel     	*con0, *con;
   correspond  	*list[4][4];
+  coord_2d **corrected;
+  double img_x, img_y; /* image center */
   
 
   /* allocate memory for lists of correspondences */
   for (i1 = 0; i1 < cpar->num_cams - 1; i1++)
     for (i2 = i1 + 1; i2 < cpar->num_cams; i2++)
-       list[i1][i2] = (correspond *) malloc (num[i1] * sizeof (correspond));
+       list[i1][i2] = (correspond *) malloc (frm->num_targets[i1] * sizeof (correspond));
 
-  con0 = (n_tupel *) malloc (4 * nmax * sizeof (n_tupel));
+   con0 = (n_tupel *) calloc(cpar->num_cams, sizeof(n_tupel));
+   con = (n_tupel *) calloc(cpar->num_cams, sizeof(n_tupel));
   
   for (i1 = 0; i1 < cpar->num_cams - 1; i1++)
     for (i2 = i1 + 1; i2 < cpar->num_cams; i2++)
-      for (i=0; i<num[i1]; i++)
+      for (i=0; i<frm->num_targets[i1]; i++)
 	{
 	  list[i1][i2][i].p1 = 0;
 	  list[i1][i2][i].n = 0;
 	}
-  	
+    	
   for (i = 0; i < nmax; i++) {
-    for (j = 0; j < 4; j++) {
+    for (j = 0; j < cpar->num_cams; j++) {
         tim[j][i] = 0;
         con0[i].p[j] = -1;
     }
-    con0[i].corr = 0;
+    con0[i].corr = 0.0;
   }
+  
+  printf("finished allocating before corrected\n");
 
-
-  /* matching  1 -> 2,3,4  +  2 -> 3,4  +  3 -> 4 */
-  for (i1 = 0; i1 < cpar->num_cams - 1; i1++)
-    for (i2 = i1 + 1; i2 < cpar->num_cams; i2++) {
-
-      for (i=0; i<num[i1]; i++)	if (geo[i1][i].x != -999) {
-          epi_mm (geo[i1][i].x, geo[i1][i].y, &(cals[i1]), &(cals[i2]), 
-          cpar->mm, vpar, &xa12, &ya12, &xb12, &yb12);
-	  
-	  /* origin point in the list */
-	  p1 = i;  list[i1][i2][p1].p1 = p1;	pt1 = geo[i1][p1].pnr;
-
-	  /* search for a conjugate point in geo[i2] */
-      count = find_candidate (geo[i2], pix[i2], num[i2],
-            xa12, ya12, xb12, yb12, 
-            pix[i1][pt1].n,pix[i1][pt1].nx,pix[i1][pt1].ny,
-            pix[i1][pt1].sumg, cand, vpar, cpar, &(cals[i2]) );
-            
-	  /* write all corresponding candidates to the preliminary list */
-	  /* of correspondences */
-	  if (count > MAXCAND)	{ count = MAXCAND; }
-	  for (j=0; j<count; j++)
-	    {
-	      list[i1][i2][p1].p2[j] = cand[j].pnr;
-	      list[i1][i2][p1].corr[j] = cand[j].corr;
-	      list[i1][i2][p1].dist[j] = cand[j].tol;
-	    }
-	  list[i1][i2][p1].n = count;
-	}
-  }
-
-  /* ------------------------------------------------------------------ */
-  /* search consistent quadruplets in the list */
-  if (cpar->num_cams == 4) {
-      for (i=0, match0=0; i<num[0]; i++)
-	{
-	  p1 = list[0][1][i].p1;
-	  for (j=0; j<list[0][1][i].n; j++)
-	    for (k=0; k<list[0][2][i].n; k++)
-	      for (l=0; l<list[0][3][i].n; l++)
-		{
-		  p2 = list[0][1][i].p2[j];
-		  p3 = list[0][2][i].p2[k];
-		  p4 = list[0][3][i].p2[l];
-		  for (m=0; m<list[1][2][p2].n; m++) {
-			p31 = list[1][2][p2].p2[m];
-            if (p3 != p31) continue;
-		    for (n=0; n<list[1][3][p2].n; n++)
-		      {
-			p41 = list[1][3][p2].p2[n];
-			if (p4 != p41) continue;
-              i3 = list[2][3][p3].n;
-			  for (o=0; o<i3; o++)
-			    {
-			      p42 = list[2][3][p3].p2[o];
-			      if (p4 == p42)
-				{
-				  corr = (list[0][1][i].corr[j]
-					  + list[0][2][i].corr[k]
-					  + list[0][3][i].corr[l]
-					  + list[1][2][p2].corr[m]
-					  + list[1][3][p2].corr[n]
-					  + list[2][3][p3].corr[o])
-				    / (list[0][1][i].dist[j]
-				       + list[0][2][i].dist[k]
-				       + list[0][3][i].dist[l]
-				       + list[1][2][p2].dist[m]
-				       + list[1][3][p2].dist[n]
-				       + list[2][3][p3].dist[o]);
-				  if (corr > vpar->corrmin)
-				    {
-				      /* accept as preliminary match */
-				      con0[match0].p[0] = p1;
-				      con0[match0].p[1] = p2;
-				      con0[match0].p[2] = p3;
-				      con0[match0].p[3] = p4;
-				      con0[match0++].corr = corr;
-				      if (match0 == 4*nmax)	/* security */
-					{
-					  printf ("Overflow in correspondences:");
-					  printf (" > %d matches\n", match0);
-					  i = num[0];
-					}
-				    }
-				}
-			    }
-              
-		      }
-            }
-		}
-	}
-
-
-      /* -------------------------------------------------------------------- */
-
-      /* sort quadruplets for match quality (.corr) */
-      quicksort_con (con0, match0);
-
-      /* -------------------------------------------------------------------- */
-
-      /* take quadruplets from the top to the bottom of the sorted list */
-      /* only if none of the points has already been used */
-      for (i=0, match=0; i<match0; i++)
-	{
-	  p1 = con0[i].p[0];	if (p1 > -1)	if (++tim[0][p1] > 1)	continue;
-	  p2 = con0[i].p[1];	if (p2 > -1)	if (++tim[1][p2] > 1)	continue;
-	  p3 = con0[i].p[2];	if (p3 > -1)	if (++tim[2][p3] > 1)	continue;
-	  p4 = con0[i].p[3];	if (p4 > -1)	if (++tim[3][p4] > 1)	continue;
-	  con[match++] = con0[i];
-	}
-
-      match4 = match;
-    }
-
-  /* ----------------------------------------------------------------------- */
-  /* ----------------------------------------------------------------------- */
-
-  /* search consistent triplets :  123, 124, 134, 234 */
-  if ((cpar->num_cams == 4 && cpar->allCam_flag == 0) || cpar->num_cams == 3)
-    {
-      //printf("Search consistent triplets \n");
-      match0 = 0;
-      for (i1 = 0; i1 < cpar->num_cams - 2; i1++)
-        for (i2 = i1 + 1; i2 < cpar->num_cams - 1; i2++)
-           for (i3 = i2 + 1; i3 < cpar->num_cams; i3++)
-				for (i=0; i<num[i1]; i++){
-					 p1 = list[i1][i2][i].p1;
-					 if (p1 > nmax  ||  tim[i1][p1] > 0)	continue;
-
-					 for (j=0; j<list[i1][i2][i].n; j++)
-					  for (k=0; k<list[i1][i3][i].n; k++) {
-						  p2 = list[i1][i2][i].p2[j];
-						  if (p2 > nmax  ||  tim[i2][p2] > 0)	continue;
-						  p3 = list[i1][i3][i].p2[k];
-						  if (p3 > nmax  ||  tim[i3][p3] > 0)	continue;
-						  						  
-						  for (m=0; m<list[i2][i3][p2].n; m++) {
-						     p31 = list[i2][i3][p2].p2[m];
-						     
-						     if (p3 == p31) {
-							    corr = (list[i1][i2][i].corr[j]
-								  + list[i1][i3][i].corr[k]
-								  + list[i2][i3][p2].corr[m])
-							    / (list[i1][i2][i].dist[j]
-							    + list[i1][i3][i].dist[k]
-							    + list[i2][i3][p2].dist[m]);
-							  if (corr > vpar->corrmin) {
-								for (n = 0; n < cpar->num_cams; n++) con0[match0].p[n] = -2;
-									con0[match0].p[i1] = p1;
-									con0[match0].p[i2] = p2;
-									con0[match0].p[i3] = p3;
-									con0[match0++].corr = corr;
-								}
-								if (match0 == 4*nmax) {   /* security */
-									printf ("Overflow in correspondences:\n");
-									printf (" > %d matches\n", match0);
-									i = num[i1]; /* Break out of the outer loop over i */
-								}
-							}
-						  }
-					    }
-					}
-
-      /* ----------------------------------------------------------------------- */
-
-      /* sort triplets for match quality (.corr) */
-      quicksort_con (con0, match0);
-
-      /* ----------------------------------------------------------------------- */
-
-      /* pragmatic version: */
-      /* take triplets from the top to the bottom of the sorted list */
-      /* only if none of the points has already been used */
-      for (i=0; i<match0; i++){
-		  p1 = con0[i].p[0];	if (p1 > -1)	if (++tim[0][p1] > 1)	continue;
-		  p2 = con0[i].p[1];	if (p2 > -1)	if (++tim[1][p2] > 1)	continue;
-		  p3 = con0[i].p[2];	if (p3 > -1)	if (++tim[2][p3] > 1)	continue;
-		  p4 = con0[i].p[3];	if (p4 > -1  && cpar->num_cams > 3) if (++tim[3][p4] > 1) continue;
-
-		  con[match] = con0[i];
-		  match++;
-	  }
-
-      match3 = match - match4;
-
-      /* repair artifact (?) */
-      if (cpar->num_cams == 3) for (i=0; i<match; i++)	con[i].p[3] = -1;
-    }
-
-  /* ----------------------------------------------------------------------- */
-  /* ----------------------------------------------------------------------- */
-
-  /* search consistent pairs :  12, 13, 14, 23, 24, 34 */
-  /* only if an object model is available or if only 2 images are used */
-      if(cpar->num_cams > 1 && cpar->allCam_flag == 0){
-		  match0 = 0;
-		  for (i1 = 0; i1 < cpar->num_cams - 1; i1++)
-			if ( cpar->num_cams == 2 || (num[0] < 64 && num[1] < 64 && num[2] < 64 && num[3] < 64))
-			  for (i2 = i1 + 1; i2 < cpar->num_cams; i2++)
-			for (i=0; i<num[i1]; i++)
-			  {
-				p1 = list[i1][i2][i].p1;
-				if (p1 > nmax  ||  tim[i1][p1] > 0)	continue;
-
-				/* take only unambigous pairs */
-				if (list[i1][i2][i].n != 1)	continue;
-
-				p2 = list[i1][i2][i].p2[0];
-				if (p2 > nmax  ||  tim[i2][p2] > 0)	continue;
-
-				corr = list[i1][i2][i].corr[0] / list[i1][i2][i].dist[0];
-
-				if (corr > vpar->corrmin)
-				  {
-				con0[match0].p[i1] = p1;
-				con0[match0].p[i2] = p2;
-				con0[match0++].corr = corr;
-				  }
-			  }
-
-		  /* ----------------------------------------------------------------------- */
-
-
-		  /* sort pairs for match quality (.corr) */
-		  quicksort_con (con0, match0);
-
-		  /* ----------------------------------------------------------------------- */
-
-
-		  /* take pairs from the top to the bottom of the sorted list */
-		  /* only if none of the points has already been used */
-		  for (i=0; i<match0; i++) {
-			  p1 = con0[i].p[0];	if (p1 > -1)	if (++tim[0][p1] > 1)	continue;
-			  p2 = con0[i].p[1];	if (p2 > -1)	if (++tim[1][p2] > 1)	continue;
-			  p3 = con0[i].p[2];	if (p3 > -1  && cpar->num_cams > 2)
-			  if (++tim[2][p3] > 1)	continue;
-			  p4 = con0[i].p[3];	if (p4 > -1  && cpar->num_cams > 3)
-			  if (++tim[3][p4] > 1)	continue;
-
-			  con[match++] = con0[i];
-			}
-		  } //end pairs?
-
-     match2 = match-match4-match3;
-    if(cpar->num_cams == 1){
-       printf ( "determined %d points from 2D", match1);
-       }
-     else{
-      printf ("%d quadruplets (red), %d triplets (green) and %d unambigous pairs\n",
-	      match4, match3, match2);
-     }
-  /* ----------------------------------------------------------------------- */
-
-  /* give each used pix the correspondence number */
-  for (i=0; i<match; i++)
-    {
-      for (j = 0; j < cpar->num_cams; j++)
-        {
-         /* Skip cameras without a correspondence obviously. */
-         if (con[i].p[j] < 0) continue;
-
-	     p1 = geo[j][con[i].p[j]].pnr;
-	     if (p1 > -1 && p1 < 1202590843)
-	      {
-	        pix[j][p1].tnr= i;
-	      }
-	    }
-    }
-
-    int count1=0;
-	j=0;
-	
-	for (i=0; i<num[j]; i++)
-	  {			      	
-	    p1 = pix[j][i].tnr;
-	    if (p1 == -1 )
-	      {
-		   count1++;
-	      }
-	  }
-    printf("unidentified objects = %d\n",count1);
-
-/* Retun values: match counts of each clique size */
-    match_counts[0] = match4;
-    match_counts[1] = match3;
-    match_counts[2] = match2;
-    match_counts[3] = match;
-
-  /* ----------------------------------------------------------------------- */
-  /* free memory for lists of correspondences */
-  for (i1 = 0; i1 < cpar->num_cams - 1; i1++)
-    for (i2 = i1 + 1; i2 < cpar->num_cams; i2++)
-        free (list[i1][i2]);
+//     We work on distortion-corrected image coordinates of particles.
+//        This loop does the correction. It also recycles the iteration on
+//        frm->num_cams to allocate some arrays needed later and do some related
+//        preparation. */
+//     corrected = (coord_2d **) malloc(frm->num_cams * sizeof(coord_2d *));
+//     for (cam = 0; cam < frm->num_cams; cam++) {
+//         corrected[cam] = (coord_2d *) malloc(
+//             frm->num_targets[cam] * sizeof(coord_2d));
+//             
+//         for (part = 0; part < frm->num_targets[cam]; part++) {
+//             pixel_to_metric(&corrected[cam][part].x, 
+//                             &corrected[cam][part].y,
+//                             frm->targets[cam][part].x, 
+//                             frm->targets[cam][part].y,
+//                             cpar);
+//             
+//             img_x = corrected[cam][part].x - calib[cam]->int_par.xh;
+//             img_y = corrected[cam][part].y - calib[cam]->int_par.yh;
+//             
+//             correct_brown_affin (img_x, img_y, calib[cam]->added_par,
+//                &corrected[cam][part].x, &corrected[cam][part].y);
+//             
+//             corrected[cam][part].pnr = frm->targets[cam][part].pnr;
+//         }
+//         
+//         This is expected by find_candidate_plus() */
+//         quicksort_coord2d_x(corrected[cam], frm->num_targets[cam]);
+//     }
+// 
+// 
+// 
+//   matching  1 -> 2,3,4  +  2 -> 3,4  +  3 -> 4 */
+//   for (i1 = 0; i1 < cpar->num_cams - 1; i1++)
+//     for (i2 = i1 + 1; i2 < cpar->num_cams; i2++) {
+// 
+//       for (i=0; i<frm->num_targets[i1]; i++)	if (corrected[i1][i].x != -999) {
+//           epi_mm (corrected[i1][i].x, corrected[i1][i].y, calib[i1], calib[i2], 
+//           cpar->mm, vpar, &xa12, &ya12, &xb12, &yb12);
+// 	  
+// 	  origin point in the list */
+// 	  p1 = i;  list[i1][i2][p1].p1 = p1;	pt1 = corrected[i1][p1].pnr;
+// 
+// 	  search for a conjugate point in corrected[i2] */
+//       count = find_candidate (corrected[i2], frm->targets[i2], frm->num_targets[i2],
+//             xa12, ya12, xb12, yb12, 
+//             frm->targets[i1][pt1].n,frm->targets[i1][pt1].nx,frm->targets[i1][pt1].ny,
+//             frm->targets[i1][pt1].sumg, cand, vpar, cpar, calib[i2] );
+//             
+// 	  write all corresponding candidates to the preliminary list */
+// 	  of correspondences */
+// 	  if (count > MAXCAND)	{ count = MAXCAND; }
+// 	  for (j=0; j<count; j++)
+// 	    {
+// 	      list[i1][i2][p1].p2[j] = cand[j].pnr;
+// 	      list[i1][i2][p1].corr[j] = cand[j].corr;
+// 	      list[i1][i2][p1].dist[j] = cand[j].tol;
+// 	    }
+// 	  list[i1][i2][p1].n = count;
+// 	}
+//   }
+//   
+//     Image coordinates not needed beyond this point. */
+//     for (cam = 0; cam < frm->num_cams; cam++) {
+//         free(corrected[cam]);
+//     }
+//     free(corrected);
+// 
+// 
+//   ------------------------------------------------------------------ */
+//   search consistent quadruplets in the list */
+//   if (cpar->num_cams == 4) {
+//       for (i=0, match0=0; i<frm->num_targets[0]; i++)
+// 	{
+// 	  p1 = list[0][1][i].p1;
+// 	  for (j=0; j<list[0][1][i].n; j++)
+// 	    for (k=0; k<list[0][2][i].n; k++)
+// 	      for (l=0; l<list[0][3][i].n; l++)
+// 		{
+// 		  p2 = list[0][1][i].p2[j];
+// 		  p3 = list[0][2][i].p2[k];
+// 		  p4 = list[0][3][i].p2[l];
+// 		  for (m=0; m<list[1][2][p2].n; m++) {
+// 			p31 = list[1][2][p2].p2[m];
+//             if (p3 != p31) continue;
+// 		    for (n=0; n<list[1][3][p2].n; n++)
+// 		      {
+// 			p41 = list[1][3][p2].p2[n];
+// 			if (p4 != p41) continue;
+//               i3 = list[2][3][p3].n;
+// 			  for (o=0; o<i3; o++)
+// 			    {
+// 			      p42 = list[2][3][p3].p2[o];
+// 			      if (p4 == p42)
+// 				{
+// 				  corr = (list[0][1][i].corr[j]
+// 					  + list[0][2][i].corr[k]
+// 					  + list[0][3][i].corr[l]
+// 					  + list[1][2][p2].corr[m]
+// 					  + list[1][3][p2].corr[n]
+// 					  + list[2][3][p3].corr[o])
+// 				    / (list[0][1][i].dist[j]
+// 				       + list[0][2][i].dist[k]
+// 				       + list[0][3][i].dist[l]
+// 				       + list[1][2][p2].dist[m]
+// 				       + list[1][3][p2].dist[n]
+// 				       + list[2][3][p3].dist[o]);
+// 				  if (corr > vpar->corrmin)
+// 				    {
+// 				      accept as preliminary match */
+// 				      con0[match0].p[0] = p1;
+// 				      con0[match0].p[1] = p2;
+// 				      con0[match0].p[2] = p3;
+// 				      con0[match0].p[3] = p4;
+// 				      con0[match0++].corr = corr;
+// 				      if (match0 == 4*nmax)	/* security */
+// 					{
+// 					  printf ("Overflow in correspondences:");
+// 					  printf (" > %d matches\n", match0);
+// 					  i = frm->num_targets[0];
+// 					}
+// 				    }
+// 				}
+// 			    }
+//               
+// 		      }
+//             }
+// 		}
+// 	}
+// 
+// 
+//       -------------------------------------------------------------------- */
+// 
+//       sort quadruplets for match quality (.corr) */
+//       quicksort_con (con0, match0);
+// 
+//       -------------------------------------------------------------------- */
+// 
+//       take quadruplets from the top to the bottom of the sorted list */
+//       only if none of the points has already been used */
+//       for (i=0, match=0; i<match0; i++)
+// 	{
+// 	  p1 = con0[i].p[0];	if (p1 > -1)	if (++tim[0][p1] > 1)	continue;
+// 	  p2 = con0[i].p[1];	if (p2 > -1)	if (++tim[1][p2] > 1)	continue;
+// 	  p3 = con0[i].p[2];	if (p3 > -1)	if (++tim[2][p3] > 1)	continue;
+// 	  p4 = con0[i].p[3];	if (p4 > -1)	if (++tim[3][p4] > 1)	continue;
+// 	  con[match++] = con0[i];
+// 	}
+// 
+//       match4 = match;
+//     }
+// 
+//   ----------------------------------------------------------------------- */
+//   ----------------------------------------------------------------------- */
+// 
+//   search consistent triplets :  123, 124, 134, 234 */
+//   if ((cpar->num_cams == 4 && cpar->allCam_flag == 0) || cpar->num_cams == 3)
+//     {
+//       //printf("Search consistent triplets \n");
+//       match0 = 0;
+//       for (i1 = 0; i1 < cpar->num_cams - 2; i1++)
+//         for (i2 = i1 + 1; i2 < cpar->num_cams - 1; i2++)
+//            for (i3 = i2 + 1; i3 < cpar->num_cams; i3++)
+// 				for (i=0; i<frm->num_targets[i1]; i++){
+// 					 p1 = list[i1][i2][i].p1;
+// 					 if (p1 > nmax  ||  tim[i1][p1] > 0)	continue;
+// 
+// 					 for (j=0; j<list[i1][i2][i].n; j++)
+// 					  for (k=0; k<list[i1][i3][i].n; k++) {
+// 						  p2 = list[i1][i2][i].p2[j];
+// 						  if (p2 > nmax  ||  tim[i2][p2] > 0)	continue;
+// 						  p3 = list[i1][i3][i].p2[k];
+// 						  if (p3 > nmax  ||  tim[i3][p3] > 0)	continue;
+// 						  						  
+// 						  for (m=0; m<list[i2][i3][p2].n; m++) {
+// 						     p31 = list[i2][i3][p2].p2[m];
+// 						     
+// 						     if (p3 == p31) {
+// 							    corr = (list[i1][i2][i].corr[j]
+// 								  + list[i1][i3][i].corr[k]
+// 								  + list[i2][i3][p2].corr[m])
+// 							    / (list[i1][i2][i].dist[j]
+// 							    + list[i1][i3][i].dist[k]
+// 							    + list[i2][i3][p2].dist[m]);
+// 							  if (corr > vpar->corrmin) {
+// 								for (n = 0; n < cpar->num_cams; n++) con0[match0].p[n] = -2;
+// 									con0[match0].p[i1] = p1;
+// 									con0[match0].p[i2] = p2;
+// 									con0[match0].p[i3] = p3;
+// 									con0[match0++].corr = corr;
+// 								}
+// 								if (match0 == 4*nmax) {   /* security */
+// 									printf ("Overflow in correspondences:\n");
+// 									printf (" > %d matches\n", match0);
+// 									i = frm->num_targets[i1]; /* Break out of the outer loop over i */
+// 								}
+// 							}
+// 						  }
+// 					    }
+// 					}
+// 
+//       ----------------------------------------------------------------------- */
+// 
+//       sort triplets for match quality (.corr) */
+//       quicksort_con (con0, match0);
+// 
+//       ----------------------------------------------------------------------- */
+// 
+//       pragmatic version: */
+//       take triplets from the top to the bottom of the sorted list */
+//       only if none of the points has already been used */
+//       for (i=0; i<match0; i++){
+// 		  p1 = con0[i].p[0];	if (p1 > -1)	if (++tim[0][p1] > 1)	continue;
+// 		  p2 = con0[i].p[1];	if (p2 > -1)	if (++tim[1][p2] > 1)	continue;
+// 		  p3 = con0[i].p[2];	if (p3 > -1)	if (++tim[2][p3] > 1)	continue;
+// 		  p4 = con0[i].p[3];	if (p4 > -1  && cpar->num_cams > 3) if (++tim[3][p4] > 1) continue;
+// 
+// 		  con[match] = con0[i];
+// 		  match++;
+// 	  }
+// 
+//       match3 = match - match4;
+// 
+//       repair artifact (?) */
+//       if (cpar->num_cams == 3) for (i=0; i<match; i++)	con[i].p[3] = -1;
+//     }
+// 
+//   ----------------------------------------------------------------------- */
+//   ----------------------------------------------------------------------- */
+// 
+//   search consistent pairs :  12, 13, 14, 23, 24, 34 */
+//   only if an object model is available or if only 2 images are used */
+//       if(cpar->num_cams > 1 && cpar->allCam_flag == 0){
+// 		  match0 = 0;
+// 		  for (i1 = 0; i1 < cpar->num_cams - 1; i1++)
+// 			if ( cpar->num_cams == 2 || (frm->num_targets[0] < 64 && 
+// 			frm->num_targets[1] < 64 && frm->num_targets[2] < 64 && 
+// 			frm->num_targets[3] < 64))
+// 			  for (i2 = i1 + 1; i2 < cpar->num_cams; i2++)
+// 			for (i=0; i<frm->num_targets[i1]; i++)
+// 			  {
+// 				p1 = list[i1][i2][i].p1;
+// 				if (p1 > nmax  ||  tim[i1][p1] > 0)	continue;
+// 
+// 				take only unambigous pairs */
+// 				if (list[i1][i2][i].n != 1)	continue;
+// 
+// 				p2 = list[i1][i2][i].p2[0];
+// 				if (p2 > nmax  ||  tim[i2][p2] > 0)	continue;
+// 
+// 				corr = list[i1][i2][i].corr[0] / list[i1][i2][i].dist[0];
+// 
+// 				if (corr > vpar->corrmin)
+// 				  {
+// 				con0[match0].p[i1] = p1;
+// 				con0[match0].p[i2] = p2;
+// 				con0[match0++].corr = corr;
+// 				  }
+// 			  }
+// 
+// 		  ----------------------------------------------------------------------- */
+// 
+// 
+// 		  sort pairs for match quality (.corr) */
+// 		  quicksort_con (con0, match0);
+// 
+// 		  ----------------------------------------------------------------------- */
+// 
+// 
+// 		  take pairs from the top to the bottom of the sorted list */
+// 		  only if none of the points has already been used */
+// 		  for (i=0; i<match0; i++) {
+// 			  p1 = con0[i].p[0];	if (p1 > -1)	if (++tim[0][p1] > 1)	continue;
+// 			  p2 = con0[i].p[1];	if (p2 > -1)	if (++tim[1][p2] > 1)	continue;
+// 			  p3 = con0[i].p[2];	if (p3 > -1  && cpar->num_cams > 2)
+// 			  if (++tim[2][p3] > 1)	continue;
+// 			  p4 = con0[i].p[3];	if (p4 > -1  && cpar->num_cams > 3)
+// 			  if (++tim[3][p4] > 1)	continue;
+// 
+// 			  con[match++] = con0[i];
+// 			}
+// 		  } //end pairs?
+// 
+//      match2 = match-match4-match3;
+//     if(cpar->num_cams == 1){
+//        printf ( "determined %d points from 2D", match1);
+//        }
+//      else{
+//       printf ("%d quadruplets (red), %d triplets (green) and %d unambigous pairs\n",
+// 	      match4, match3, match2);
+//      }
+//   ----------------------------------------------------------------------- */
+// 
+//   give each used pix the correspondence number */
+//   for (i=0; i<match; i++)
+//     {
+//       for (j = 0; j < cpar->num_cams; j++)
+//         {
+//          Skip cameras without a correspondence obviously. */
+//          if (con[i].p[j] < 0) continue;
+// 
+// 	     p1 = corrected[j][con[i].p[j]].pnr;
+// 	     if (p1 > -1 && p1 < 1202590843)
+// 	      {
+// 	        frm->targets[j][p1].tnr= i;
+// 	      }
+// 	    }
+//     }
+// 
+//     int count1=0;
+// 	j=0;
+// 	
+// 	for (i=0; i < frm->num_targets[j]; i++)
+// 	  {			      	
+// 	    p1 = frm->targets[j][i].tnr;
+// 	    if (p1 == -1 )
+// 	      {
+// 		   count1++;
+// 	      }
+// 	  }
+//     printf("unidentified objects = %d\n",count1);
+// 
+// Retun values: match counts of each clique size */
+//     match_counts[0] = match4;
+//     match_counts[1] = match3;
+//     match_counts[2] = match2;
+//     match_counts[3] = match;
+// 
+//   ----------------------------------------------------------------------- */
+//   free memory for lists of correspondences */
+//   for (i1 = 0; i1 < cpar->num_cams - 1; i1++)
+//     for (i2 = i1 + 1; i2 < cpar->num_cams; i2++)
+//         free (list[i1][i2]);
 
   free (con0);
 
-  return match;
+  return con;
 }
 

--- a/liboptv/src/correspondences.c
+++ b/liboptv/src/correspondences.c
@@ -1,0 +1,500 @@
+/****************************************************************************
+
+Routine:	       	correspondences.c
+
+Author/Copyright:      	Hans-Gerd Maas
+
+Address:	      	Institute of Geodesy and Photogrammetry
+	      		ETH - Hoenggerberg
+	      		CH - 8093 Zurich
+
+Creation Date:	       	1988/89
+
+Description:	       	establishment of correspondences for 2/3/4 cameras
+
+****************************************************************************/
+
+#include <optv/epi.h>
+#include "correspondences.h"
+#include "tools.h"
+
+/* quicksort for list of correspondences in order of match quality */
+/* 4 camera version */
+
+
+void qs_con (con, left, right)
+n_tupel	*con;
+int    	left, right;
+{
+  register int	i, j;
+  double       	xm;
+  n_tupel      	temp;
+
+  i = left;	j = right;	xm = con[(left+right)/2].corr;
+
+  do
+    {
+      while (con[i].corr > xm  &&  i<right)	i++;
+      while (xm > con[j].corr  &&  j>left)	j--;
+
+      if (i <= j)
+	{
+	  temp = con[i];
+	  con[i] = con[j];
+	  con[j] = temp;
+	  i++;	j--;
+	}
+    }
+  while (i <= j);
+
+  if (left < j)	qs_con (con, left, j);
+  if (i < right)	qs_con (con, i, right);
+}
+
+void quicksort_con (con, num)
+n_tupel	*con;
+int    	num;
+{
+  qs_con (con, 0, num-1);
+}
+
+/* quicksort of targets in y-order */
+
+void qs_target_y (target *pix, int left, int right) {
+  register int	i, j;
+  double ym;
+  target temp;
+
+  i = left;	j = right;	ym = pix[(left+right)/2].y;
+
+  do {
+      while (pix[i].y < ym  &&  i<right)	i++;
+      while (ym < pix[j].y  &&  j>left)	j--;
+
+      if (i <= j) {
+        temp = pix[i];
+        pix[i] = pix[j];
+        pix[j] = temp;
+        i++; j--;
+      }
+  } while (i <= j);
+
+  if (left < j)	qs_target_y (pix, left, j);
+  if (i < right) qs_target_y (pix, i, right);
+}
+
+void quicksort_target_y (target *pix, int num) {
+  qs_target_y (pix, 0, num-1);
+}
+
+
+/* quicksort of 2d coordinates in x-order */
+
+void qs_coord2d_x (crd, left, right)
+coord_2d	*crd;
+int			left, right;
+{
+	register int	i, j;
+	double			xm;
+	coord_2d		temp;
+
+	i = left;	j = right;	xm = crd[(left+right)/2].x;
+
+	do
+	{
+		while (crd[i].x < xm  &&  i<right)	i++;
+		while (xm < crd[j].x  &&  j>left)	j--;
+
+		if (i <= j)
+		{
+			temp = crd[i];
+			crd[i] = crd[j];
+			crd[j] = temp;
+			i++;	j--;
+		}
+	}
+	while (i <= j);
+
+	if (left < j)	qs_coord2d_x (crd, left, j);
+	if (i < right)	qs_coord2d_x (crd, i, right);
+}
+
+void quicksort_coord2d_x (coord_2d *crd, int num) {
+	qs_coord2d_x (crd, 0, num-1);
+}
+
+/****************************************************************************/
+/*--------------- 4 camera model: consistent quadruplets -------------------*/
+/****************************************************************************/
+
+int correspondences_4 (target pix[][nmax], coord_2d geo[][nmax], int num[], 
+    volume_par *vpar, control_par *cpar, Calibration cals[], n_tupel *con, 
+    int match_counts[])
+{
+  int 	i,j,k,l,m,n,o,  i1,i2,i3;
+  int   count, match, match0=0, match4=0, match3=0, match2=0, match1=0;
+  int 	p1,p2,p3,p4, p31, p41, p42;
+  int  	pt1;
+  int 	tim[4][nmax];
+  double       	xa12,ya12,xb12,yb12,X,Y,Z;
+  double       	corr;
+  candidate   	cand[maxcand];
+  n_tupel     	*con0;
+  correspond  	*list[4][4];
+  vec3d out;
+  FILE *fp1;
+
+  for (j=0; j<4; j++) for (i=0; i<nmax; i++) tim[j][i] = 0;
+
+  /* allocate memory for lists of correspondences */
+  for (i1 = 0; i1 < cpar->num_cams - 1; i1++)
+    for (i2 = i1 + 1; i2 < cpar->num_cams; i2++)
+    list[i1][i2] = (correspond *) malloc (num[i1] * sizeof (correspond));
+
+  con0 = (n_tupel *) malloc (4*nmax * sizeof (n_tupel));
+
+  /*  initialize ...  */
+  match=0; match0=0; match2=0;
+
+  for (i1 = 0; i1 < cpar->num_cams - 1; i1++)
+    for (i2 = i1 + 1; i2 < cpar->num_cams; i2++)
+      for (i=0; i<num[i1]; i++)
+	{
+	  list[i1][i2][i].p1 = 0;
+	  list[i1][i2][i].n = 0;
+	}
+  for (i = 0; i < nmax; i++) {
+    for (j = 0; j < 4; j++) {
+        tim[j][i] = 0;
+        con0[i].p[j] = -1;
+    }
+    con0[i].corr = 0;
+  }
+
+  /* -------------if only one cam and 2D--------- */ //by Beat Lüthi June 2007
+/*
+  if(cpar->num_cams == 1){
+	  if(res_name[0]==0){
+          sprintf (res_name, "rt_is");
+	  }
+	 fp1 = fopen (res_name, "w");
+		fprintf (fp1, "%4d\n", num[0]);
+	  for (i=0; i<num[0]; i++){
+          epi_mm_2D (geo[0][i].x,geo[0][i].y, &(cals[0]), 
+            cpar->mm, vpar, out);
+          pix[0][geo[0][i].pnr].tnr=i;
+		  fprintf (fp1, "%4d", i+1);
+		  fprintf (fp1, " %9.3f %9.3f %9.3f", X, Y, Z);
+          fprintf (fp1, " %4d", geo[0][i].pnr);
+          fprintf (fp1, " %4d", -1);
+          fprintf (fp1, " %4d", -1);
+          fprintf (fp1, " %4d\n", -1);
+	  }
+	  fclose (fp1);
+	  match1=num[0];
+  }
+*/
+  /* -------------end of only one cam and 2D ------------ */
+
+  /* matching  1 -> 2,3,4  +  2 -> 3,4  +  3 -> 4 */
+  for (i1 = 0; i1 < cpar->num_cams - 1; i1++)
+    for (i2 = i1 + 1; i2 < cpar->num_cams; i2++) {
+     //printf ("Establishing correspondences  %d - %d\n", i1, i2);
+     /* establish correspondences from num[i1] points of img[i1] to img[i2] */
+
+      for (i=0; i<num[i1]; i++)	if (geo[i1][i].x != -999) {
+          epi_mm (geo[i1][i].x, geo[i1][i].y, &(cals[i1]), &(cals[i2]), 
+          cpar->mm, vpar, &xa12, &ya12, &xb12, &yb12);
+	  
+    /////ich glaube, da muss ich einsteigen, wenn alles erledigt ist.
+	  ///////mit bild_1 x,y Epipole machen und dann selber was schreiben um die Distanz zu messen.
+	  ///////zu Punkt in bild_2.
+
+	  /* origin point in the list */
+	  p1 = i;  list[i1][i2][p1].p1 = p1;	pt1 = geo[i1][p1].pnr;
+
+	  /* search for a conjugate point in geo[i2] */
+      count = find_candidate (geo[i2], pix[i2], num[i2],
+            xa12, ya12, xb12, yb12, 
+            pix[i1][pt1].n,pix[i1][pt1].nx,pix[i1][pt1].ny,
+            pix[i1][pt1].sumg, cand, vpar, cpar, &(cals[i2]) );
+	  /* write all corresponding candidates to the preliminary list */
+	  /* of correspondences */
+	  if (count > maxcand)	{ count = maxcand; }
+	  for (j=0; j<count; j++)
+	    {
+	      list[i1][i2][p1].p2[j] = cand[j].pnr;
+	      list[i1][i2][p1].corr[j] = cand[j].corr;
+	      list[i1][i2][p1].dist[j] = cand[j].tol;
+	    }
+	  list[i1][i2][p1].n = count;
+	}
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* search consistent quadruplets in the list */
+  if (cpar->num_cams == 4) {
+      for (i=0, match0=0; i<num[0]; i++)
+	{
+	  p1 = list[0][1][i].p1;
+	  for (j=0; j<list[0][1][i].n; j++)
+	    for (k=0; k<list[0][2][i].n; k++)
+	      for (l=0; l<list[0][3][i].n; l++)
+		{
+		  p2 = list[0][1][i].p2[j];
+		  p3 = list[0][2][i].p2[k];
+		  p4 = list[0][3][i].p2[l];
+		  for (m=0; m<list[1][2][p2].n; m++) {
+			p31 = list[1][2][p2].p2[m];
+            if (p3 != p31) continue;
+		    for (n=0; n<list[1][3][p2].n; n++)
+		      {
+			p41 = list[1][3][p2].p2[n];
+			if (p4 != p41) continue;
+              i3 = list[2][3][p3].n;
+			  for (o=0; o<i3; o++)
+			    {
+			      p42 = list[2][3][p3].p2[o];
+			      if (p4 == p42)
+				{
+				  corr = (list[0][1][i].corr[j]
+					  + list[0][2][i].corr[k]
+					  + list[0][3][i].corr[l]
+					  + list[1][2][p2].corr[m]
+					  + list[1][3][p2].corr[n]
+					  + list[2][3][p3].corr[o])
+				    / (list[0][1][i].dist[j]
+				       + list[0][2][i].dist[k]
+				       + list[0][3][i].dist[l]
+				       + list[1][2][p2].dist[m]
+				       + list[1][3][p2].dist[n]
+				       + list[2][3][p3].dist[o]);
+				  if (corr > vpar->corrmin)
+				    {
+				      /* accept as preliminary match */
+				      con0[match0].p[0] = p1;
+				      con0[match0].p[1] = p2;
+				      con0[match0].p[2] = p3;
+				      con0[match0].p[3] = p4;
+				      con0[match0++].corr = corr;
+				      if (match0 == 4*nmax)	/* security */
+					{
+					  printf ("Overflow in correspondences:");
+					  printf (" > %d matches\n", match0);
+					  i = num[0];
+					}
+				    }
+				}
+			    }
+              
+		      }
+            }
+		}
+	}
+
+
+      /* -------------------------------------------------------------------- */
+
+      /* sort quadruplets for match quality (.corr) */
+      quicksort_con (con0, match0);
+
+      /* -------------------------------------------------------------------- */
+
+      /* take quadruplets from the top to the bottom of the sorted list */
+      /* only if none of the points has already been used */
+      for (i=0, match=0; i<match0; i++)
+	{
+	  p1 = con0[i].p[0];	if (p1 > -1)	if (++tim[0][p1] > 1)	continue;
+	  p2 = con0[i].p[1];	if (p2 > -1)	if (++tim[1][p2] > 1)	continue;
+	  p3 = con0[i].p[2];	if (p3 > -1)	if (++tim[2][p3] > 1)	continue;
+	  p4 = con0[i].p[3];	if (p4 > -1)	if (++tim[3][p4] > 1)	continue;
+	  con[match++] = con0[i];
+	}
+
+      match4 = match;
+    }
+
+  /* ----------------------------------------------------------------------- */
+  /* ----------------------------------------------------------------------- */
+
+  /* search consistent triplets :  123, 124, 134, 234 */
+  if ((cpar->num_cams == 4 && cpar->allCam_flag == 0) || cpar->num_cams == 3)
+    {
+      //printf("Search consistent triplets \n");
+      match0 = 0;
+      for (i1 = 0; i1 < cpar->num_cams - 2; i1++)
+        for (i2 = i1 + 1; i2 < cpar->num_cams - 1; i2++)
+           for (i3 = i2 + 1; i3 < cpar->num_cams; i3++)
+				for (i=0; i<num[i1]; i++){
+					 p1 = list[i1][i2][i].p1;
+					 if (p1 > nmax  ||  tim[i1][p1] > 0)	continue;
+
+					 for (j=0; j<list[i1][i2][i].n; j++)
+					  for (k=0; k<list[i1][i3][i].n; k++) {
+						  p2 = list[i1][i2][i].p2[j];
+						  if (p2 > nmax  ||  tim[i2][p2] > 0)	continue;
+						  p3 = list[i1][i3][i].p2[k];
+						  if (p3 > nmax  ||  tim[i3][p3] > 0)	continue;
+						  						  
+						  for (m=0; m<list[i2][i3][p2].n; m++) {
+						     p31 = list[i2][i3][p2].p2[m];
+						     
+						     if (p3 == p31) {
+							    corr = (list[i1][i2][i].corr[j]
+								  + list[i1][i3][i].corr[k]
+								  + list[i2][i3][p2].corr[m])
+							    / (list[i1][i2][i].dist[j]
+							    + list[i1][i3][i].dist[k]
+							    + list[i2][i3][p2].dist[m]);
+							  if (corr > vpar->corrmin) {
+								for (n = 0; n < cpar->num_cams; n++) con0[match0].p[n] = -2;
+									con0[match0].p[i1] = p1;
+									con0[match0].p[i2] = p2;
+									con0[match0].p[i3] = p3;
+									con0[match0++].corr = corr;
+								}
+								if (match0 == 4*nmax) {   /* security */
+									printf ("Overflow in correspondences:\n");
+									printf (" > %d matches\n", match0);
+									i = num[i1]; /* Break out of the outer loop over i */
+								}
+							}
+						  }
+					    }
+					}
+
+      /* ----------------------------------------------------------------------- */
+
+      /* sort triplets for match quality (.corr) */
+      quicksort_con (con0, match0);
+
+      /* ----------------------------------------------------------------------- */
+
+      /* pragmatic version: */
+      /* take triplets from the top to the bottom of the sorted list */
+      /* only if none of the points has already been used */
+      for (i=0; i<match0; i++){
+		  p1 = con0[i].p[0];	if (p1 > -1)	if (++tim[0][p1] > 1)	continue;
+		  p2 = con0[i].p[1];	if (p2 > -1)	if (++tim[1][p2] > 1)	continue;
+		  p3 = con0[i].p[2];	if (p3 > -1)	if (++tim[2][p3] > 1)	continue;
+		  p4 = con0[i].p[3];	if (p4 > -1  && cpar->num_cams > 3) if (++tim[3][p4] > 1) continue;
+
+		  con[match] = con0[i];
+		  match++;
+	  }
+
+      match3 = match - match4;
+
+      /* repair artifact (?) */
+      if (cpar->num_cams == 3) for (i=0; i<match; i++)	con[i].p[3] = -1;
+    }
+
+  /* ----------------------------------------------------------------------- */
+  /* ----------------------------------------------------------------------- */
+
+  /* search consistent pairs :  12, 13, 14, 23, 24, 34 */
+  /* only if an object model is available or if only 2 images are used */
+      if(cpar->num_cams > 1 && cpar->allCam_flag == 0){
+		  match0 = 0;
+		  for (i1 = 0; i1 < cpar->num_cams - 1; i1++)
+			if ( cpar->num_cams == 2 || (num[0] < 64 && num[1] < 64 && num[2] < 64 && num[3] < 64))
+			  for (i2 = i1 + 1; i2 < cpar->num_cams; i2++)
+			for (i=0; i<num[i1]; i++)
+			  {
+				p1 = list[i1][i2][i].p1;
+				if (p1 > nmax  ||  tim[i1][p1] > 0)	continue;
+
+				/* take only unambigous pairs */
+				if (list[i1][i2][i].n != 1)	continue;
+
+				p2 = list[i1][i2][i].p2[0];
+				if (p2 > nmax  ||  tim[i2][p2] > 0)	continue;
+
+				corr = list[i1][i2][i].corr[0] / list[i1][i2][i].dist[0];
+
+				if (corr > vpar->corrmin)
+				  {
+				con0[match0].p[i1] = p1;
+				con0[match0].p[i2] = p2;
+				con0[match0++].corr = corr;
+				  }
+			  }
+
+		  /* ----------------------------------------------------------------------- */
+
+
+		  /* sort pairs for match quality (.corr) */
+		  quicksort_con (con0, match0);
+
+		  /* ----------------------------------------------------------------------- */
+
+
+		  /* take pairs from the top to the bottom of the sorted list */
+		  /* only if none of the points has already been used */
+		  for (i=0; i<match0; i++) {
+			  p1 = con0[i].p[0];	if (p1 > -1)	if (++tim[0][p1] > 1)	continue;
+			  p2 = con0[i].p[1];	if (p2 > -1)	if (++tim[1][p2] > 1)	continue;
+			  p3 = con0[i].p[2];	if (p3 > -1  && cpar->num_cams > 2)
+			  if (++tim[2][p3] > 1)	continue;
+			  p4 = con0[i].p[3];	if (p4 > -1  && cpar->num_cams > 3)
+			  if (++tim[3][p4] > 1)	continue;
+
+			  con[match++] = con0[i];
+			}
+		  } //end pairs?
+
+     match2 = match-match4-match3;
+    if(cpar->num_cams == 1){
+       printf ( "determined %d points from 2D", match1);
+       }
+     else{
+      printf ("%d quadruplets (red), %d triplets (green) and %d unambigous pairs\n",
+	      match4, match3, match2);
+     }
+  /* ----------------------------------------------------------------------- */
+
+  /* give each used pix the correspondence number */
+  for (i=0; i<match; i++)
+    {
+      for (j = 0; j < cpar->num_cams; j++)
+	{
+      /* Skip cameras without a correspondence obviously. */
+      if (con[i].p[j] < 0) continue;
+
+	  p1 = geo[j][con[i].p[j]].pnr;
+	  if (p1 > -1 && p1 < 1202590843)
+	    {
+	      pix[j][p1].tnr= i;
+	    }
+	}
+    }
+  /* draw crosses on canvas */
+    int count1=0;
+	j=0;
+	for (i=0; i<num[j]; i++)
+	  {			      	
+	    p1 = pix[j][i].tnr;
+	    if (p1 == -1 )
+	      {
+		count1++;
+	      }
+	  }
+printf("unidentified objects = %d\n",count1);
+
+/* Retun values: match counts of each clique size */
+  match_counts[0] = match4;
+  match_counts[1] = match3;
+  match_counts[2] = match2;
+  match_counts[3] = match;
+
+  /* ----------------------------------------------------------------------- */
+  /* free memory for lists of correspondences */
+  for (i1 = 0; i1 < cpar->num_cams - 1; i1++)
+    for (i2 = i1 + 1; i2 < cpar->num_cams; i2++)
+        free (list[i1][i2]);
+
+  free (con0);
+
+  return match;
+}
+

--- a/liboptv/src/correspondences.c
+++ b/liboptv/src/correspondences.c
@@ -14,18 +14,17 @@ Description:	       	establishment of correspondences for 2/3/4 cameras
 
 ****************************************************************************/
 
-#include <optv/epi.h>
+
 #include "correspondences.h"
-#include "tools.h"
+
+
+// #include "tools.h"
 
 /* quicksort for list of correspondences in order of match quality */
 /* 4 camera version */
 
 
-void qs_con (con, left, right)
-n_tupel	*con;
-int    	left, right;
-{
+void qs_con (n_tupel *con, int left, int right){
   register int	i, j;
   double       	xm;
   n_tupel      	temp;
@@ -47,20 +46,30 @@ int    	left, right;
     }
   while (i <= j);
 
-  if (left < j)	qs_con (con, left, j);
-  if (i < right)	qs_con (con, i, right);
+  if (left < j)	 qs_con (con, left, j);
+  if (i < right) qs_con (con, i, right);
 }
 
-void quicksort_con (con, num)
-n_tupel	*con;
-int    	num;
-{
+/* quicksort_con is helper function to run the 
+   qs_con() when the left = 0, right = num - 1
+*/
+void quicksort_con (n_tupel	*con, int num){
   qs_con (con, 0, num-1);
 }
 
-/* quicksort of targets in y-order */
-
-void qs_target_y (target *pix, int left, int right) {
+/* qs_target_y() uses quicksort algorithm to 
+   sort targets in y-order.
+   Arguments:
+   pointer to an array of targets *pix
+   left, right are integers positions in the
+   array. To sort the complete array, use
+   qs_target_y(target *pix, 0, len(pix)-1)
+   according to https://en.wikipedia.org/wiki/Quicksort
+   Note: 
+   y in OpenPTV is the vertical direction, 
+   x is from left to right and z towards the camera
+*/
+void qs_target_y (target *pix, int left, int right){
   register int	i, j;
   double ym;
   target temp;
@@ -138,7 +147,7 @@ int correspondences_4 (target pix[][nmax], coord_2d geo[][nmax], int num[],
   int 	tim[4][nmax];
   double       	xa12,ya12,xb12,yb12,X,Y,Z;
   double       	corr;
-  candidate   	cand[maxcand];
+  candidate   	cand[MAXCAND];
   n_tupel     	*con0;
   correspond  	*list[4][4];
   vec3d out;
@@ -220,7 +229,7 @@ int correspondences_4 (target pix[][nmax], coord_2d geo[][nmax], int num[],
             pix[i1][pt1].sumg, cand, vpar, cpar, &(cals[i2]) );
 	  /* write all corresponding candidates to the preliminary list */
 	  /* of correspondences */
-	  if (count > maxcand)	{ count = maxcand; }
+	  if (count > MAXCAND)	{ count = MAXCAND; }
 	  for (j=0; j<count; j++)
 	    {
 	      list[i1][i2][p1].p2[j] = cand[j].pnr;

--- a/liboptv/src/correspondences.c
+++ b/liboptv/src/correspondences.c
@@ -507,9 +507,9 @@ int take_best_candidates(n_tupel *src, n_tupel *dst,
 n_tupel *correspondences (frame *frm, coord_2d **corrected, 
   volume_par *vpar, control_par *cpar, Calibration **calib, int match_counts[])
 {
-  int 	i,j,k,m,n,i1,i2,i3,cam;
+  int 	i,j,i1,i2,cam;
   int   match=0, match0=0, match4=0, match3=0, match2=0, match1=0;
-  int 	p1,p2,p3,p4, p31;
+  int 	p1,p2,p3,p4;
   double       	corr;
   n_tupel     	*con0, *con;
   correspond  	*list[4][4];

--- a/liboptv/src/correspondences.c
+++ b/liboptv/src/correspondences.c
@@ -181,7 +181,7 @@ Calibration **calib, int match_counts[]) {
         fprintf(stderr, "out of memory\n");
         return NULL;
         }
-    for(i = 0; i < nmax; i++)
+    for(i = 0; i < cpar->num_cams; i++)
         {
         tim[i] = malloc(nmax * sizeof(int));
         if(tim[i] == NULL)

--- a/liboptv/src/correspondences.c
+++ b/liboptv/src/correspondences.c
@@ -327,7 +327,7 @@ int four_camera_matching(correspond *list[4][4], int base_target_count,
                   
                   matched++;
                   if (matched == scratch_size) {
-                      printf ("Overflow in correspondences.");
+                      printf ("Overflow in correspondences.\n");
                       return matched;
                   }
               }
@@ -379,7 +379,7 @@ void match_pairs(correspond *list[4][4], coord_2d **corrected,
                     list[i1][i2][i].corr[j] = cand[j].corr;
                     list[i1][i2][i].dist[j] = cand[j].tol;
                 }
-	        list[i1][i2][i].n = count;
+                list[i1][i2][i].n = count;
             }
         }
     }

--- a/liboptv/src/correspondences.c
+++ b/liboptv/src/correspondences.c
@@ -338,6 +338,24 @@ int four_camera_matching(correspond *list[4][4], int base_target_count,
     return matched;
 }
 
+/*  three_camera_matching() marks candidate 3-cliques found from adjacency 
+    lists.
+    
+    Arguments:
+    correspond *list[4][4] - the pairwise adjacency lists.
+    int num_cams - the number of cameras in the scene.
+    int *target_counts - number of turgets in each camera.
+    double accept_corr - minimal correspondence grade for acceptance.
+    n_tupel *scratch - scratch buffer to fill with candidate clique data.
+    int scratch_size - size of the scratch space. Upon reaching it, the search
+        is terminated and only the candidates found by then are returned.
+    int **tusage - record of currently used/unused targets in each camera.
+        Targets that are already marked used (e.g. by quadruplets) will not be
+        taken to build triplets.
+    
+    Returns:
+    int, the number of candidate cliques found.
+*/
 int three_camera_matching(correspond *list[4][4], int num_cams, 
     int *target_counts, double accept_corr, n_tupel *scratch, int scratch_size,
     int** tusage)
@@ -348,12 +366,12 @@ int three_camera_matching(correspond *list[4][4], int num_cams,
     int p1, p2, p3; /* pair indicators */
     double corr;
     
-    for (i1 = 0; i1 < num_cams - 2; i1++)
-        for (i = 0; i < target_counts[i1]; i++) {            
-            for (i2 = i1 + 1; i2 < num_cams - 1; i2++)
+    for (i1 = 0; i1 < num_cams - 2; i1++) {
+        for (i = 0; i < target_counts[i1]; i++) {
+            for (i2 = i1 + 1; i2 < num_cams - 1; i2++) {
                 p1 = list[i1][i2][i].p1;
                 if (p1 > nmax || tusage[i1][p1] > 0) continue;
-
+                
                 for (j = 0; j < list[i1][i2][i].n; j++) {
                     p2 = list[i1][i2][i].p2[j];
                     if (p2 > nmax || tusage[i2][p2] > 0) continue;
@@ -393,7 +411,9 @@ int three_camera_matching(correspond *list[4][4], int num_cams,
                                 }
                             }
                     }
+                }
             }
+        }
     }
     return matched;
 }

--- a/liboptv/src/correspondences.c
+++ b/liboptv/src/correspondences.c
@@ -189,7 +189,7 @@ int** safely_allocate_target_usage_marks(int num_cams) {
             tusage[cam] = NULL; /* So free() can be called without corruption */
         }
     }
-    if (error = 0) 
+    if (error == 0) 
         return tusage;
     
     deallocate_target_usage_marks(tusage, num_cams);

--- a/liboptv/src/correspondences.c
+++ b/liboptv/src/correspondences.c
@@ -273,7 +273,7 @@ n_tupel *correspondences (frame *frm, volume_par *vpar, control_par *cpar,
         preparation. 
 */
     
-    corrected = (coord_2d **) malloc(cpar->num_cams * sizeof(coord_2d *));    
+    corrected = (coord_2d **) malloc(cpar->num_cams * sizeof(coord_2d *));
     for (cam = 0; cam < cpar->num_cams; cam++) {
         corrected[cam] = (coord_2d *) malloc(
             frm->num_targets[cam] * sizeof(coord_2d));
@@ -284,15 +284,12 @@ n_tupel *correspondences (frame *frm, volume_par *vpar, control_par *cpar,
             
             
         for (part = 0; part < frm->num_targets[cam]; part++) {
-        printf("%f %f \n", frm->targets[cam][part].x, frm->targets[cam][part].y);
             pixel_to_metric(&corrected[cam][part].x, 
                             &corrected[cam][part].y,
                             frm->targets[cam][part].x, 
                             frm->targets[cam][part].y,
                             cpar);
                             
-            printf("%f %f \n", corrected[cam][part].x, corrected[cam][part].y);
-            
             img_x = corrected[cam][part].x - calib[cam]->int_par.xh;
             img_y = corrected[cam][part].y - calib[cam]->int_par.yh;
             
@@ -300,15 +297,12 @@ n_tupel *correspondences (frame *frm, volume_par *vpar, control_par *cpar,
                &corrected[cam][part].x, &corrected[cam][part].y);
             
             corrected[cam][part].pnr = frm->targets[cam][part].pnr;
-            
-            // printf('%f %f %d \n', corrected[cam][part].x, corrected[cam][part].y, corrected[cam][part].pnr);
-            printf("%f %f %d \n", corrected[cam][part].x, corrected[cam][part].y, corrected[cam][part].pnr);
         }
         
         /* This is expected by find_candidate_plus() */
         quicksort_coord2d_x(corrected[cam], frm->num_targets[cam]);
     }
- 
+
 /*   matching  1 -> 2,3,4  +  2 -> 3,4  +  3 -> 4 */
   for (i1 = 0; i1 < cpar->num_cams - 1; i1++)
     for (i2 = i1 + 1; i2 < cpar->num_cams; i2++) {
@@ -316,10 +310,6 @@ n_tupel *correspondences (frame *frm, volume_par *vpar, control_par *cpar,
       for (i=0; i<frm->num_targets[i1]; i++)	if (corrected[i1][i].x != -999) {
           epi_mm (corrected[i1][i].x, corrected[i1][i].y, calib[i1], calib[i2], 
           cpar->mm, vpar, &xa12, &ya12, &xb12, &yb12);
-          
-          // printf('%f %f\n', corrected[i1][i].x, corrected[i1][i].y);
-          // printf('%f %f %f %f\n', xa12, ya12, xb12, yb12);
-          
 	  
           /* origin point in the list */
 	      p1 = i;  list[i1][i2][p1].p1 = p1;	pt1 = corrected[i1][p1].pnr;
@@ -342,12 +332,6 @@ n_tupel *correspondences (frame *frm, volume_par *vpar, control_par *cpar,
 	  list[i1][i2][p1].n = count;
 	}
   }
-  
-    /* Image coordinates not needed beyond this point. */
-    for (cam = 0; cam < frm->num_cams; cam++) {
-        free(corrected[cam]);
-    }
-    free(corrected);
 
 /*   search consistent quadruplets in the list */
   if (cpar->num_cams == 4) {
@@ -558,11 +542,10 @@ n_tupel *correspondences (frame *frm, volume_par *vpar, control_par *cpar,
         {
          /* Skip cameras without a correspondence obviously. */
          if (con[i].p[j] < 0) continue;
-
-	     p1 = corrected[j][con[i].p[j]].pnr;
+             p1 = corrected[j][con[i].p[j]].pnr;
 	     if (p1 > -1 && p1 < 1202590843)
 	      {
-	        frm->targets[j][p1].tnr= i;
+                frm->targets[j][p1].tnr= i;
 	      }
 	    }
     }
@@ -586,6 +569,12 @@ n_tupel *correspondences (frame *frm, volume_par *vpar, control_par *cpar,
     match_counts[2] = match2;
     match_counts[3] = match;
 
+/* Image coordinates not needed beyond this point. */
+    for (cam = 0; cam < frm->num_cams; cam++) {
+        free(corrected[cam]);
+    }
+    free(corrected);
+    
 /*   free memory for lists of correspondences */
   for (i1 = 0; i1 < cpar->num_cams - 1; i1++)
     for (i2 = i1 + 1; i2 < cpar->num_cams; i2++)

--- a/liboptv/src/correspondences.c
+++ b/liboptv/src/correspondences.c
@@ -584,6 +584,31 @@ int take_best_candidates(n_tupel *src, n_tupel *dst,
 /*         Full correspondence process                                      */
 /****************************************************************************/
 
+/*  correspondences() generates a list of tuple target numbers (one for each
+    camera), denoting the set of targets all corresponding to one 3D position. 
+    Candidates are preferred by the number of cameras invoilved (more is 
+    better) and the correspondence score calculated using epipolar lines.
+    
+    Arguments:
+    frame *frm - a frame struct holding the observed targets and their number
+        for each camera.
+    coord_2d **corrected - for each camera, an array of the flat-image 
+        coordinates corresponding to the targets in frm (the .pnr property
+        says which is which), sorted by the X coordinate. 
+    volume_par *vpar - epipolar search zone and criteria for correspondence.
+    control_par *cpar - general scene parameters s.a. image size.
+    Calibration **calib - array of pointers to each camera's calibration 
+        parameters.
+    
+    Output Arguments:
+    int match_counts[] - output buffer, as long as the number of cameras.
+        stores the number of matches for each clique size, in descending
+        clique size order. The last element stores the total.
+    
+    Returns:
+    n_tupel con - the sorted list of correspondences in descending quality
+        order.
+*/
 n_tupel *correspondences (frame *frm, coord_2d **corrected, 
   volume_par *vpar, control_par *cpar, Calibration **calib, int match_counts[])
 {

--- a/liboptv/src/correspondences.c
+++ b/liboptv/src/correspondences.c
@@ -389,16 +389,15 @@ void match_pairs(correspond *list[4][4], coord_2d **corrected,
 /*         Full correspondence process                                      */
 /****************************************************************************/
 
-n_tupel *correspondences (frame *frm, volume_par *vpar, control_par *cpar, 
-  Calibration **calib, int match_counts[]) 
+n_tupel *correspondences (frame *frm, coord_2d **corrected, 
+  volume_par *vpar, control_par *cpar, Calibration **calib, int match_counts[])
 {
-  int 	i,j,k,m,n,i1,i2,i3,cam,part;
+  int 	i,j,k,m,n,i1,i2,i3,cam;
   int   match=0, match0=0, match4=0, match3=0, match2=0, match1=0;
   int 	p1,p2,p3,p4, p31;
   double       	corr;
   n_tupel     	*con0, *con;
   correspond  	*list[4][4];
-  coord_2d **corrected;
   int **tim;
   
   /* Allocation of scratch buffers for internal tasks and return-value 
@@ -435,44 +434,6 @@ n_tupel *correspondences (frame *frm, volume_par *vpar, control_par *cpar,
         con0[i].p[j] = -1;
     }
     con0[i].corr = 0.0;
-  }
-
-  /*  We work on distortion-corrected image coordinates of particles.
-      This loop does the correction and also sets point numbers correctly.
-      I have a feeling that this should not happen here, because the correction
-      is used both for this and for point positions, so the function should 
-      receive it as argument.
-  */
-  
-  corrected = (coord_2d **) malloc(cpar->num_cams * sizeof(coord_2d *));
-  for (cam = 0; cam < cpar->num_cams; cam++) {
-      corrected[cam] = (coord_2d *) malloc(
-          frm->num_targets[cam] * sizeof(coord_2d));
-      if (corrected[cam] == NULL){
-          fprintf(stderr, "corrected is not allocated");
-          deallocate_adjacency_lists(list, cpar->num_cams);
-          deallocate_target_usage_marks(tim, cpar->num_cams);
-          free(con0);
-          free(con);
-          return NULL;
-      }
-            
-      for (part = 0; part < frm->num_targets[cam]; part++) {
-          pixel_to_metric(&corrected[cam][part].x, 
-                          &corrected[cam][part].y,
-                          frm->targets[cam][part].x, 
-                          frm->targets[cam][part].y,
-                          cpar);
-                            
-          dist_to_flat(corrected[cam][part].x, corrected[cam][part].y,
-              calib[cam], &corrected[cam][part].x, &corrected[cam][part].y,
-              0.00001);
-          
-          corrected[cam][part].pnr = frm->targets[cam][part].pnr;
-      }
-        
-      /* This is expected by find_candidate() */
-      quicksort_coord2d_x(corrected[cam], frm->num_targets[cam]);
   }
 
   /* Generate adjacency lists: mark candidates for correspondence.

--- a/liboptv/src/correspondences.c
+++ b/liboptv/src/correspondences.c
@@ -395,7 +395,7 @@ int three_camera_matching(correspond *list[4][4], int num_cams,
                                 if (corr <= accept_corr)
                                     continue;
                                 
-                                /* This to catch the 4th (excluded )camera */
+                                /* This to catch the 4th (excluded) camera */
                                 for (n = 0; n < num_cams; n++) 
                                     scratch[matched].p[n] = -2;
                                 
@@ -422,6 +422,21 @@ int three_camera_matching(correspond *list[4][4], int num_cams,
 /*         Other components of the correspondence process                   */
 /****************************************************************************/
 
+/*  match_pairs() finds for each target in each source camera the candidate
+    targets for correspondence on the other cameras by projecting epipolar 
+    lines.
+    
+    Arguments:
+    correspond *list[4][4] - pairwise adjacency lists to be filled with the
+        results. Each is a buffer long enough to contain data for all targets
+        in the source camera of the pair.
+    coord_2d **corrected - the flat-image metric coordinates of targets, by
+        camera, x-sorted. Epipolar lines are projected in flat coordinates.
+    frame *frm - frame data and reference target properties (similarity of
+        size and brightness are used to determine correlation score).
+    volume_par *vpar, control_par *cpar, Calibration **calib - scene 
+        parameters.
+*/
 void match_pairs(correspond *list[4][4], coord_2d **corrected, 
     frame *frm, volume_par *vpar, control_par *cpar, Calibration **calib) 
 {
@@ -464,6 +479,26 @@ void match_pairs(correspond *list[4][4], coord_2d **corrected,
     }
 }
 
+/*  take_best_candidates() takes candidates out of a candidate list by their
+    correlation measure. A candidate is not taken if it has been marked used
+    for a larger clique or for a same-size clique with a better correlation 
+    score.
+    
+    Arguments:
+    n_tupel *src - the array of candidates. sorted in place by correlation 
+        score.
+    n_tupel *dst - an array to receive the chosen cliques in order. Must have
+        enough space allocated.
+    int num_cams - the number of cameras in the scene, which defines the size
+        of other parameters.
+    int num_cands - number of elements in ``src``.
+    int **tusage - record of currently used/unused targets in each camera.
+        Targets that are already marked used (e.g. by quadruplets) will not be
+        taken.
+    
+    Returns:
+    the number of cliques taken from the candidate list.
+*/
 int take_best_candidates(n_tupel *src, n_tupel *dst, 
     int num_cams, int num_cands, int **tusage) 
 {

--- a/liboptv/src/correspondences.c
+++ b/liboptv/src/correspondences.c
@@ -451,6 +451,12 @@ int consistent_pair_matching(correspond *list[4][4], int num_cams,
                 scratch[matched].p[i1] = p1;
                 scratch[matched].p[i2] = p2;
                 scratch[matched].corr = corr;
+                
+                matched++;
+                if (matched == scratch_size) {
+                    printf ("Overflow in correspondences.\n");
+                    return matched;
+                }
             }
         }
     }

--- a/liboptv/src/orientation.c
+++ b/liboptv/src/orientation.c
@@ -18,8 +18,6 @@
 #include <string.h>
 #include <math.h>
 
-
-#define PT_UNUSED -999
 #define NUM_ITER  80
 #define POS_INF 1E20
 #define CONVERGENCE 0.00001

--- a/liboptv/tests/CMakeLists.txt
+++ b/liboptv/tests/CMakeLists.txt
@@ -46,6 +46,9 @@ add_dependencies(check_epi optv)
 add_executable(check_segmentation EXCLUDE_FROM_ALL check_segmentation.c)
 add_dependencies(check_segmentation optv)
 
+add_executable(check_correspondences EXCLUDE_FROM_ALL check_correspondences.c)
+add_dependencies(check_correspondences optv)
+
 
 set(LIBS ${LIBS} ${CHECK_LIBRARIES} optv)
 
@@ -147,9 +150,18 @@ add_custom_command(TARGET check_segmentation PRE_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory
     ${CMAKE_CURRENT_SOURCE_DIR}/testing_fodder $<TARGET_FILE_DIR:check_segmentation>/testing_fodder)
 
+
+target_link_libraries(check_correspondences ${LIBS})
+add_test(check_correspondences ${CMAKE_CURRENT_BINARY_DIR}/check_correspondences)
+
+add_custom_command(TARGET check_correspondences PRE_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+    ${CMAKE_CURRENT_SOURCE_DIR}/testing_fodder $<TARGET_FILE_DIR:check_correspondences>/testing_fodder)
+
     
 add_custom_target(verify COMMAND ${CMAKE_CTEST_COMMAND})
 add_dependencies(verify check_fb check_calibration check_parameters check_lsqadj 
 check_ray_tracing check_trafo check_vec_utils check_image_proc check_multimed 
-check_imgcoord check_orientation check_epi check_sortgrid check_segmentation)
+check_imgcoord check_orientation check_epi check_sortgrid check_segmentation 
+check_correspondences)
 

--- a/liboptv/tests/check_correspondences.c
+++ b/liboptv/tests/check_correspondences.c
@@ -142,7 +142,7 @@ START_TEST(test_correspondences)
     int subset_size, num_corres;
     n_tupel *corres;
     
-    ck_abort_msg("Known failure: j/p2 in find_candidate_plus breaks this.");
+    // ck_abort_msg("Known failure: j/p2 in find_candidate_plus breaks this.");
     chdir("testing_fodder/");
     init_proc_c();
     
@@ -179,7 +179,11 @@ START_TEST(test_correspondences)
         }
     }
     vpar = read_volume_par("parameters/criteria.par");
-    corres_lists = correspondences(&frm, calib, vpar, cpar);
+    // corres_lists = correspondences(&frm, calib, vpar, cpar);
+    match = correspondences(targ, coord_2d geo[][nmax], frm.num_targets, 
+    vpar, cpar, calib, corres, 
+    int match_counts[]); 
+    
     fail_unless(corres_lists[0] == NULL);
     
     for (subset_size = 2; subset_size <= num_cams; subset_size++) {

--- a/liboptv/tests/check_correspondences.c
+++ b/liboptv/tests/check_correspondences.c
@@ -155,13 +155,14 @@ START_TEST(test_correspondences)
     for (cam = 0; cam < num_cams; cam++) {
         sprintf(ori_name, ori_tmpl, cam + 1);
         puts(ori_name);
-       calib[cam] = read_calibration(ori_name, "testing_fodder/cal/cam1.tif.addpar", NULL);
+        calib[cam] = read_calibration(ori_name, "testing_fodder/cal/cam1.tif.addpar", NULL);
         
         
        frm.num_targets[cam] = 16;
         
         /* Construct a scene representing a calibration target, generate
            tergets for it, then use them to reconstruct correspondences. */
+        printf("Constructing the targets\n");
         for (cpt_horz = 0; cpt_horz < 4; cpt_horz++) {
             for (cpt_vert = 0; cpt_vert < 4; cpt_vert++) {
                 cpt_ix = cpt_horz*4 + cpt_vert;
@@ -173,6 +174,8 @@ START_TEST(test_correspondences)
                 vec_set(tmp, cpt_vert * 10, cpt_horz * 10, 0);
                 img_coord(tmp, calib[cam], &media_par, &(targ->x), &(targ->y));
                 metric_to_pixel(&(targ->x), &(targ->y), targ->x, targ->y, cpar);
+                printf("targ[%d] %f %f %d\n", cpt_ix, frm.targets[cam][cpt_ix].x, 
+                frm.targets[cam][cpt_ix].y, frm.targets[cam][cpt_ix].pnr);
                 
                 /* These values work in check_epi, so used here too */
                 targ->n = 25;
@@ -181,10 +184,10 @@ START_TEST(test_correspondences)
             }
         }
     }
-       
-       vpar = read_volume_par("testing_fodder/parameters/criteria.par");
+       fail_if((cpar = read_control_par("testing_fodder/parameters/ptv.par"))== 0);
+       fail_if((vpar = read_volume_par("testing_fodder/parameters/criteria.par"))==0);
     
-       con = correspondences(&frm, calib, vpar, cpar, &match_counts); 
+       con = correspondences(&frm, vpar, cpar, calib, &match_counts);
     
 //     fail_unless(con[0] == NULL);
     

--- a/liboptv/tests/check_correspondences.c
+++ b/liboptv/tests/check_correspondences.c
@@ -128,13 +128,15 @@ START_TEST(test_correspondences)
     Calibration *calib[4];
     volume_par *vpar;
     control_par *cpar;
-    n_tupel **corres_lists;
-    mm_np media_par = {1, 1., {1., 0., 0.}, {1., 0., 0.}, 1., 1.};
+    n_tupel *con;
+    mm_np media_par = {1, 1., {1., 0., 0.}, {1., 0., 0.}, 1.};
+    
     vec3d tmp;
+    int match_counts[4];
 
     
-    char ori_tmpl[] = "cal/sym_cam%d.tif.ori";
-    char ori_name[25]; 
+    char ori_tmpl[] = "testing_fodder/cal/sym_cam%d.tif.ori";
+    char ori_name[40]; 
     
     int num_cams = 4, cam, cpt_vert, cpt_horz, cpt_ix;
     target *targ;
@@ -143,8 +145,8 @@ START_TEST(test_correspondences)
     n_tupel *corres;
     
     // ck_abort_msg("Known failure: j/p2 in find_candidate_plus breaks this.");
-    chdir("testing_fodder/");
-    init_proc_c();
+    // chdir("testing_fodder/");
+    // init_proc_c();
     
     int i,j;
     /* Four cameras on 4 quadrants looking down into a calibration target.
@@ -152,10 +154,11 @@ START_TEST(test_correspondences)
     frame_init(&frm, num_cams, 16);
     for (cam = 0; cam < num_cams; cam++) {
         sprintf(ori_name, ori_tmpl, cam + 1);
-        calib[cam] = read_calibration(ori_name, "cal/cam1.tif.addpar", NULL);
+        puts(ori_name);
+       calib[cam] = read_calibration(ori_name, "testing_fodder/cal/cam1.tif.addpar", NULL);
         
         
-        frm.num_targets[cam] = 16;
+       frm.num_targets[cam] = 16;
         
         /* Construct a scene representing a calibration target, generate
            tergets for it, then use them to reconstruct correspondences. */
@@ -178,24 +181,23 @@ START_TEST(test_correspondences)
             }
         }
     }
-    vpar = read_volume_par("parameters/criteria.par");
-    // corres_lists = correspondences(&frm, calib, vpar, cpar);
-    match = correspondences(targ, coord_2d geo[][nmax], frm.num_targets, 
-    vpar, cpar, calib, corres, 
-    int match_counts[]); 
+       
+       vpar = read_volume_par("testing_fodder/parameters/criteria.par");
     
-    fail_unless(corres_lists[0] == NULL);
+       con = correspondences(&frm, calib, vpar, cpar, &match_counts); 
     
-    for (subset_size = 2; subset_size <= num_cams; subset_size++) {
-        corres = corres_lists[subset_size - 1];
-        num_corres = 0;
-        
-        while (corres->corr >= 0) {
-            num_corres++;
-            corres++;
-        }
-        fail_unless(num_corres == ((subset_size == 4) ? 16 : 0));
-    }
+//     fail_unless(con[0] == NULL);
+    
+//     for (subset_size = 2; subset_size <= num_cams; subset_size++) {
+//         corres = corres_lists[subset_size - 1];
+//         num_corres = 0;
+//         
+//         while (corres->corr >= 0) {
+//             num_corres++;
+//             corres++;
+//         }
+//         fail_unless(num_corres == ((subset_size == 4) ? 16 : 0));
+//     }
 }
 END_TEST
 

--- a/liboptv/tests/check_correspondences.c
+++ b/liboptv/tests/check_correspondences.c
@@ -144,17 +144,16 @@ START_TEST(test_correspondences)
     int subset_size, num_corres;
     n_tupel *corres;
     
-    // ck_abort_msg("Known failure: j/p2 in find_candidate_plus breaks this.");
-    // chdir("testing_fodder/");
-    // init_proc_c();
+   fail_if((cpar = read_control_par("testing_fodder/parameters/ptv.par"))== 0);
+   fail_if((vpar = read_volume_par("testing_fodder/parameters/criteria.par"))==0);
     
     int i,j;
     /* Four cameras on 4 quadrants looking down into a calibration target.
        Calibration taken from an actual experimental setup */
     frame_init(&frm, num_cams, 16);
+    
     for (cam = 0; cam < num_cams; cam++) {
         sprintf(ori_name, ori_tmpl, cam + 1);
-        puts(ori_name);
         calib[cam] = read_calibration(ori_name, "testing_fodder/cal/cam1.tif.addpar", NULL);
         
         
@@ -184,8 +183,7 @@ START_TEST(test_correspondences)
             }
         }
     }
-       fail_if((cpar = read_control_par("testing_fodder/parameters/ptv.par"))== 0);
-       fail_if((vpar = read_volume_par("testing_fodder/parameters/criteria.par"))==0);
+
     
        con = correspondences(&frm, vpar, cpar, calib, &match_counts);
     

--- a/liboptv/tests/check_correspondences.c
+++ b/liboptv/tests/check_correspondences.c
@@ -1,0 +1,88 @@
+/*  Unit tests for functions related to finding calibration parameters. Uses
+    the Check framework: http://check.sourceforge.net/
+
+    To run it, type "make verify" when in the src/build/
+    after installing the library.
+
+    If that doesn't run the tests, use the Check tutorial:
+    http://check.sourceforge.net/doc/check_html/check_3.html
+*/
+
+#include <check.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <math.h>
+
+#include "orientation.h"
+#include "calibration.h"
+#include "vec_utils.h"
+#include "parameters.h"
+#include "imgcoord.h"
+#include "sortgrid.h"
+#include "trafo.h"
+#include "correspondences.h"
+
+#define RO 200./M_PI
+
+
+START_TEST(test_qs_target_y)
+{
+    target test_pix[] = {
+        {0, 0.0, -0.2, 5, 1, 2, 10, -999},
+        {6, 0.2, 0.0, 10, 8, 1, 20, -999},
+        {3, 0.2, 0.8, 10, 3, 3, 30, -999},
+        {4, 0.4, -1.1, 10, 3, 3, 40, -999},
+        {1, 0.7, -0.1, 10, 3, 3, 50, -999},
+        {7, 1.2, 0.3, 10, 3, 3, 60, -999},
+        {5, 10.4, 0.1, 10, 3, 3, 70, -999}
+    };
+
+    /* sorting test_pix vertically by 'y' */
+    qs_target_y (test_pix, 0, 6);
+
+    /* first point should be -1.1 and the last 0.8 */
+    fail_unless (fabs(test_pix[0].y + 1.1) < 1E-6);
+    fail_unless (fabs(test_pix[1].y + 0.2) < 1E-6);
+    fail_unless (fabs(test_pix[6].y - 0.8) < 1E-6);
+}
+END_TEST
+
+
+
+
+Suite* orient_suite(void) {
+    Suite *s = suite_create ("Testing correspondences");
+
+    TCase *tc = tcase_create ("quicksort target y");
+    tcase_add_test(tc, test_qs_target_y);
+    suite_add_tcase (s, tc);
+
+//     tc = tcase_create ("Point position");
+//     tcase_add_test(tc, test_point_position);
+//     suite_add_tcase (s, tc);
+// 
+//     tc = tcase_create ("Convergence measures");
+//     tcase_add_test(tc, test_convergence_measure);
+//     suite_add_tcase (s, tc);
+//     
+//     tc = tcase_create ("Raw orientation");
+//     tcase_add_test(tc, test_raw_orient);
+//     suite_add_tcase (s, tc);
+// 
+//     tc = tcase_create ("Orientation");
+//     tcase_add_test(tc, test_orient);
+//     suite_add_tcase (s, tc);
+
+    return s;
+}
+
+int main(void) {
+    int number_failed;
+    Suite *s = orient_suite();
+    SRunner *sr = srunner_create (s);
+    srunner_run_all (sr, CK_ENV);
+    number_failed = srunner_ntests_failed (sr);
+    srunner_free (sr);
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/liboptv/tests/check_correspondences.c
+++ b/liboptv/tests/check_correspondences.c
@@ -276,6 +276,7 @@ START_TEST(test_correspondences)
     Calibration *calib[4];
     volume_par *vpar;
     control_par *cpar;
+    coord_2d **corrected;
     n_tupel *con;
     int cam, match_counts[4];
     
@@ -298,7 +299,8 @@ START_TEST(test_correspondences)
     }
     
     frm = generate_test_set(calib, cpar, vpar);
-    con = correspondences(frm, vpar, cpar, calib, match_counts);
+    corrected = correct_frame(frm, calib, cpar, 0.0001);
+    con = correspondences(frm, corrected, vpar, cpar, calib, match_counts);
     
     /* The example set is built to have all 16 quadruplets. */
     fail_unless(match_counts[0] == 16);

--- a/liboptv/tests/check_correspondences.c
+++ b/liboptv/tests/check_correspondences.c
@@ -14,17 +14,12 @@
 #include <unistd.h>
 #include <math.h>
 
-#include "orientation.h"
 #include "calibration.h"
 #include "vec_utils.h"
 #include "parameters.h"
 #include "imgcoord.h"
-#include "sortgrid.h"
 #include "trafo.h"
 #include "correspondences.h"
-
-#define RO 200./M_PI
-
 
 START_TEST(test_qs_target_y)
 {

--- a/liboptv/tests/check_correspondences.c
+++ b/liboptv/tests/check_correspondences.c
@@ -48,32 +48,100 @@ START_TEST(test_qs_target_y)
 }
 END_TEST
 
+START_TEST(test_quicksort_target_y)
+{
+    int num; 
+    target test_pix[] = {
+        {0, 0.0, -0.2, 5, 1, 2, 10, -999},
+        {6, 0.2, 0.0, 10, 8, 1, 20, -999},
+        {3, 0.2, 0.8, 10, 3, 3, 30, -999},
+        {4, 0.4, -1.1, 10, 3, 3, 40, -999},
+        {1, 0.7, -0.1, 10, 3, 3, 50, -999},
+        {7, 1.2, 0.3, 10, 3, 3, 60, -999},
+        {5, 10.4, 0.1, 10, 3, 3, 70, -999}
+    };
+    
+    /* sorting test_pix vertically by 'y' */
+    num = sizeof(test_pix)/sizeof(test_pix[0]);
+    quicksort_target_y (test_pix, num);
+
+    /* first point should be -1.1 and the last 0.8 */
+    fail_unless (fabs(test_pix[0].y + 1.1) < 1E-6);
+    fail_unless (fabs(test_pix[1].y + 0.2) < 1E-6);
+    fail_unless (fabs(test_pix[num-1].y - 0.8) < 1E-6);
+    
+
+    
+}
+END_TEST
+
+START_TEST(test_quicksort_coord2d_x)
+{
+    			   
+    int num = 7; /* length of the test_crd */
+
+    /* coord_2d is int pnr, double x,y */
+    coord_2d test_crd[] = {
+        {0, 0.0, 0.0},
+        {6, 0.1, 0.1}, /* best candidate, right on the diagonal */
+        {3, 0.2, -0.8},
+        {4, -0.4, -1.1},
+        {1, 0.7, -0.1},
+        {7, 1.2, 0.3},
+        {5, 10.4, 0.1}
+    };
+
+    quicksort_coord2d_x(test_crd, num);
+   
+    /* first point should be -0.4 and the last 10.4 */
+    fail_unless (fabs(test_crd[0].x + 0.4) < 1E-6);
+    fail_unless (fabs(test_crd[1].x - 0.0) < 1E-6);
+    fail_unless (fabs(test_crd[num-1].x - 10.4) < 1E-6);	
+}
+END_TEST
+
+START_TEST(test_quicksort_con)
+{
+    			   
+    int i, num = 3; /* length of the test_crd */
+    
+    n_tupel test_con[] = {
+        {{0, 1, 2, 3}, 0.1},
+        {{0, 1, 2, 3}, 0.2},
+        {{0, 1, 2, 3}, 0.15}
+    };
+
+    quicksort_con(test_con, num);
+
+   
+    /* first point should be -0.4 and the last 10.4 */
+    fail_unless (fabs(test_con[0].corr - 0.2) < 1E-6);
+    fail_unless (fabs(test_con[2].corr - 0.1) < 1E-6);
+   
+	
+}
+END_TEST
 
 
 
 Suite* orient_suite(void) {
     Suite *s = suite_create ("Testing correspondences");
 
-    TCase *tc = tcase_create ("quicksort target y");
+    TCase *tc = tcase_create ("qs target y");
     tcase_add_test(tc, test_qs_target_y);
     suite_add_tcase (s, tc);
 
-//     tc = tcase_create ("Point position");
-//     tcase_add_test(tc, test_point_position);
-//     suite_add_tcase (s, tc);
-// 
-//     tc = tcase_create ("Convergence measures");
-//     tcase_add_test(tc, test_convergence_measure);
-//     suite_add_tcase (s, tc);
-//     
-//     tc = tcase_create ("Raw orientation");
-//     tcase_add_test(tc, test_raw_orient);
-//     suite_add_tcase (s, tc);
-// 
-//     tc = tcase_create ("Orientation");
-//     tcase_add_test(tc, test_orient);
-//     suite_add_tcase (s, tc);
+    tc = tcase_create ("quicksort_target_y");
+    tcase_add_test(tc, test_quicksort_target_y);
+    suite_add_tcase (s, tc);
 
+    tc = tcase_create ("quicksort_coord2d_x");
+    tcase_add_test(tc, test_quicksort_coord2d_x);
+    suite_add_tcase (s, tc);
+    
+    tc = tcase_create ("quicksort_con");
+    tcase_add_test(tc, test_quicksort_con);
+    suite_add_tcase (s, tc);
     return s;
 }
 

--- a/liboptv/tests/check_correspondences.c
+++ b/liboptv/tests/check_correspondences.c
@@ -119,6 +119,18 @@ END_TEST
 
 /* Tests of correspondence components and full process using dummy data */
 
+void read_all_calibration(Calibration *calib[4], control_par *cpar) {
+    char ori_tmpl[] = "testing_fodder/cal/sym_cam%d.tif.ori";
+    char added_name[] = "testing_fodder/cal/cam1.tif.addpar";
+    char ori_name[40];
+    int cam;
+    
+    for (cam = 0; cam < cpar->num_cams; cam++) {
+        sprintf(ori_name, ori_tmpl, cam + 1);
+        calib[cam] = read_calibration(ori_name, added_name, NULL);
+    }
+}
+
 /* generate_test_set() generates data for targets on 4 cameras. The targets
  * Are organized on a 4x4 grid, 10mm apart.
  */
@@ -215,9 +227,6 @@ START_TEST(test_pairwise_matching)
     coord_2d **corrected;
     int cam, subcam, part, cand, correct_pnr;
     
-    char ori_tmpl[] = "testing_fodder/cal/sym_cam%d.tif.ori";
-    char ori_name[40];
-    
     fail_if((cpar = read_control_par("testing_fodder/parameters/ptv.par"))== 0);
     fail_if((vpar = read_volume_par("testing_fodder/parameters/criteria.par"))==0);
     
@@ -226,10 +235,7 @@ START_TEST(test_pairwise_matching)
     cpar->mm->n2[0] = 1.0001;
     cpar->mm->n3 = 1.0001;
     
-    for (cam = 0; cam < cpar->num_cams; cam++) {
-        sprintf(ori_name, ori_tmpl, cam + 1);
-        calib[cam] = read_calibration(ori_name, "testing_fodder/cal/cam1.tif.addpar", NULL);
-    }
+    read_all_calibration(calib, cpar);
     frm = generate_test_set(calib, cpar, vpar);
     
     corrected = correct_frame(frm, calib, cpar, 0.0001);
@@ -281,9 +287,6 @@ START_TEST(test_four_camera_matching)
     n_tupel *con;
     int cam, matched;
     
-    char ori_tmpl[] = "testing_fodder/cal/sym_cam%d.tif.ori";
-    char ori_name[40];
-    
     fail_if((cpar = read_control_par("testing_fodder/parameters/ptv.par"))== 0);
     fail_if((vpar = read_volume_par("testing_fodder/parameters/criteria.par"))==0);
     
@@ -292,10 +295,7 @@ START_TEST(test_four_camera_matching)
     cpar->mm->n2[0] = 1.0001;
     cpar->mm->n3 = 1.0001;
     
-    for (cam = 0; cam < cpar->num_cams; cam++) {
-        sprintf(ori_name, ori_tmpl, cam + 1);
-        calib[cam] = read_calibration(ori_name, "testing_fodder/cal/cam1.tif.addpar", NULL);
-    }
+    read_all_calibration(calib, cpar);
     frm = generate_test_set(calib, cpar, vpar);
 
     corrected = correct_frame(frm, calib, cpar, 0.0001);
@@ -325,11 +325,6 @@ START_TEST(test_correspondences)
     n_tupel *con;
     int cam, match_counts[4];
     
-    char ori_tmpl[] = "testing_fodder/cal/sym_cam%d.tif.ori";
-    char ori_name[40];
-    
-    n_tupel *corres;
-    
     fail_if((cpar = read_control_par("testing_fodder/parameters/ptv.par"))== 0);
     fail_if((vpar = read_volume_par("testing_fodder/parameters/criteria.par"))==0);
     
@@ -338,11 +333,7 @@ START_TEST(test_correspondences)
     cpar->mm->n2[0] = 1.0001;
     cpar->mm->n3 = 1.0001;
         
-    for (cam = 0; cam < cpar->num_cams; cam++) {
-        sprintf(ori_name, ori_tmpl, cam + 1);
-        calib[cam] = read_calibration(ori_name, "testing_fodder/cal/cam1.tif.addpar", NULL);
-    }
-    
+    read_all_calibration(calib, cpar);
     frm = generate_test_set(calib, cpar, vpar);
     corrected = correct_frame(frm, calib, cpar, 0.0001);
     con = correspondences(frm, corrected, vpar, cpar, calib, match_counts);

--- a/liboptv/tests/check_correspondences.c
+++ b/liboptv/tests/check_correspondences.c
@@ -144,8 +144,8 @@ START_TEST(test_correspondences)
     int subset_size, num_corres;
     n_tupel *corres;
     
-   fail_if((cpar = read_control_par("testing_fodder/parameters/ptv.par"))== 0);
-   fail_if((vpar = read_volume_par("testing_fodder/parameters/criteria.par"))==0);
+    fail_if((cpar = read_control_par("testing_fodder/parameters/ptv.par"))== 0);
+    fail_if((vpar = read_volume_par("testing_fodder/parameters/criteria.par"))==0);
     
     int i,j;
     /* Four cameras on 4 quadrants looking down into a calibration target.
@@ -156,8 +156,7 @@ START_TEST(test_correspondences)
         sprintf(ori_name, ori_tmpl, cam + 1);
         calib[cam] = read_calibration(ori_name, "testing_fodder/cal/cam1.tif.addpar", NULL);
         
-        
-       frm.num_targets[cam] = 16;
+        frm.num_targets[cam] = 16;
         
         /* Construct a scene representing a calibration target, generate
            tergets for it, then use them to reconstruct correspondences. */
@@ -183,9 +182,8 @@ START_TEST(test_correspondences)
             }
         }
     }
-
     
-       con = correspondences(&frm, vpar, cpar, calib, &match_counts);
+    con = correspondences(&frm, vpar, cpar, calib, &match_counts);
     
 //     fail_unless(con[0] == NULL);
     

--- a/liboptv/tests/check_correspondences.c
+++ b/liboptv/tests/check_correspondences.c
@@ -375,6 +375,62 @@ START_TEST(test_three_camera_matching)
 }
 END_TEST
 
+START_TEST(test_two_camera_matching)
+{
+    /* the overall setup is the same as the 4-camera test, with the following
+       changes: targets are darkenned in two cameras to get 16 pairs. */
+    frame *frm;
+    target *targ;
+    
+    Calibration *calib[4];
+    volume_par *vpar;
+    control_par *cpar;
+    
+    correspond *list[4][4];
+    coord_2d **corrected;
+    n_tupel *con;
+    int **tusage;
+    
+    int cam, matched, part;
+    
+    fail_if((cpar = read_control_par("testing_fodder/parameters/ptv.par"))== 0);
+    fail_if((vpar = read_volume_par("testing_fodder/parameters/criteria.par"))==0);
+    
+    cpar->mm->n2[0] = 1.0001;
+    cpar->mm->n3 = 1.0001;
+    vpar->Zmin_lay[0] = -1;
+    vpar->Zmin_lay[1] = -1;
+    vpar->Zmax_lay[0] = 1;
+    vpar->Zmax_lay[1] = 1;
+    
+    read_all_calibration(calib, cpar);
+    frm = generate_test_set(calib, cpar, vpar);
+    
+    cpar->num_cams = 2;
+    corrected = correct_frame(frm, calib, cpar, 0.0001);
+    safely_allocate_adjacency_lists(list, cpar->num_cams, frm->num_targets);
+    match_pairs(list, corrected, frm, vpar, cpar, calib);
+    
+    con = (n_tupel *) malloc(4*16*sizeof(n_tupel));
+    tusage = safely_allocate_target_usage_marks(cpar->num_cams);
+    
+    /* high accept corr bcz of closeness to epipolar lines. */
+    matched = consistent_pair_matching(list, 2, frm->num_targets, 10000., con, 
+        4*16, tusage);
+    
+    fail_unless(matched == 16);
+    
+    /* Clean up */
+    for (cam = 0; cam < cpar->num_cams; cam++) 
+        free(corrected[cam]);
+    deallocate_adjacency_lists(list, cpar->num_cams);
+    deallocate_target_usage_marks(tusage, cpar->num_cams);
+    free(con);
+    free(vpar);
+    free_control_par(cpar);
+}
+END_TEST
+
 START_TEST(test_correspondences)
 {
     frame *frm;
@@ -407,7 +463,7 @@ START_TEST(test_correspondences)
 END_TEST
 
 
-Suite* orient_suite(void) {
+Suite* corresp_suite(void) {
     Suite *s = suite_create ("Testing correspondences");
 
     TCase *tc = tcase_create ("qs target y");
@@ -441,12 +497,17 @@ Suite* orient_suite(void) {
     tc = tcase_create ("Three camera matching");
     tcase_add_test(tc, test_three_camera_matching);
     suite_add_tcase (s, tc);
+
+    tc = tcase_create ("Two camera matching");
+    tcase_add_test(tc, test_two_camera_matching);
+    suite_add_tcase (s, tc);
+
     return s;
 }
 
 int main(void) {
     int number_failed;
-    Suite *s = orient_suite();
+    Suite *s = corresp_suite();
     SRunner *sr = srunner_create (s);
     srunner_run_all (sr, CK_ENV);
     number_failed = srunner_ntests_failed (sr);

--- a/liboptv/tests/check_correspondences.c
+++ b/liboptv/tests/check_correspondences.c
@@ -160,7 +160,6 @@ START_TEST(test_correspondences)
         
         /* Construct a scene representing a calibration target, generate
            tergets for it, then use them to reconstruct correspondences. */
-        printf("Constructing the targets\n");
         for (cpt_horz = 0; cpt_horz < 4; cpt_horz++) {
             for (cpt_vert = 0; cpt_vert < 4; cpt_vert++) {
                 cpt_ix = cpt_horz*4 + cpt_vert;
@@ -172,8 +171,6 @@ START_TEST(test_correspondences)
                 vec_set(tmp, cpt_vert * 10, cpt_horz * 10, 0);
                 img_coord(tmp, calib[cam], &media_par, &(targ->x), &(targ->y));
                 metric_to_pixel(&(targ->x), &(targ->y), targ->x, targ->y, cpar);
-                printf("targ[%d] %f %f %d\n", cpt_ix, frm.targets[cam][cpt_ix].x, 
-                frm.targets[cam][cpt_ix].y, frm.targets[cam][cpt_ix].pnr);
                 
                 /* These values work in check_epi, so used here too */
                 targ->n = 25;
@@ -183,20 +180,13 @@ START_TEST(test_correspondences)
         }
     }
     
-    con = correspondences(&frm, vpar, cpar, calib, &match_counts);
+    con = correspondences(&frm, vpar, cpar, calib, match_counts);
     
-//     fail_unless(con[0] == NULL);
-    
-//     for (subset_size = 2; subset_size <= num_cams; subset_size++) {
-//         corres = corres_lists[subset_size - 1];
-//         num_corres = 0;
-//         
-//         while (corres->corr >= 0) {
-//             num_corres++;
-//             corres++;
-//         }
-//         fail_unless(num_corres == ((subset_size == 4) ? 16 : 0));
-//     }
+    /* The example set is built to have all 16 quadruplets. */
+    fail_unless(match_counts[0] == 16);
+    fail_unless(match_counts[1] == 0);
+    fail_unless(match_counts[2] == 0);
+    fail_unless(match_counts[3] == 16); /* last elemnt is the sum of matches */
 }
 END_TEST
 

--- a/liboptv/tests/check_correspondences.c
+++ b/liboptv/tests/check_correspondences.c
@@ -147,6 +147,11 @@ START_TEST(test_correspondences)
     fail_if((cpar = read_control_par("testing_fodder/parameters/ptv.par"))== 0);
     fail_if((vpar = read_volume_par("testing_fodder/parameters/criteria.par"))==0);
     
+    /* Cameras are at so high angles that opposing cameras don't see each other
+       in the normal air-glass-water setting. */
+    cpar->mm->n2[0] = 1.0001;
+    cpar->mm->n3 = 1.0001;
+    
     int i,j;
     /* Four cameras on 4 quadrants looking down into a calibration target.
        Calibration taken from an actual experimental setup */

--- a/liboptv/tests/check_correspondences.c
+++ b/liboptv/tests/check_correspondences.c
@@ -362,7 +362,6 @@ START_TEST(test_three_camera_matching)
     matched = three_camera_matching(list, 4, frm->num_targets, 100000., con, 
         4*16, tusage);
     
-    printf("matched %d\n", matched);
     fail_unless(matched == 16);
     
     /* Clean up */

--- a/liboptv/tests/check_correspondences.c
+++ b/liboptv/tests/check_correspondences.c
@@ -122,6 +122,78 @@ START_TEST(test_quicksort_con)
 }
 END_TEST
 
+START_TEST(test_correspondences)
+{
+    frame frm;
+    Calibration *calib[4];
+    volume_par *vpar;
+    control_par *cpar;
+    n_tupel **corres_lists;
+    mm_np media_par = {1, 1., {1., 0., 0.}, {1., 0., 0.}, 1., 1.};
+    vec3d tmp;
+
+    
+    char ori_tmpl[] = "cal/sym_cam%d.tif.ori";
+    char ori_name[25]; 
+    
+    int num_cams = 4, cam, cpt_vert, cpt_horz, cpt_ix;
+    target *targ;
+    
+    int subset_size, num_corres;
+    n_tupel *corres;
+    
+    ck_abort_msg("Known failure: j/p2 in find_candidate_plus breaks this.");
+    chdir("testing_fodder/");
+    init_proc_c();
+    
+    int i,j;
+    /* Four cameras on 4 quadrants looking down into a calibration target.
+       Calibration taken from an actual experimental setup */
+    frame_init(&frm, num_cams, 16);
+    for (cam = 0; cam < num_cams; cam++) {
+        sprintf(ori_name, ori_tmpl, cam + 1);
+        calib[cam] = read_calibration(ori_name, "cal/cam1.tif.addpar", NULL);
+        
+        
+        frm.num_targets[cam] = 16;
+        
+        /* Construct a scene representing a calibration target, generate
+           tergets for it, then use them to reconstruct correspondences. */
+        for (cpt_horz = 0; cpt_horz < 4; cpt_horz++) {
+            for (cpt_vert = 0; cpt_vert < 4; cpt_vert++) {
+                cpt_ix = cpt_horz*4 + cpt_vert;
+                if (cam % 2) cpt_ix = 15 - cpt_ix; /* Avoid symmetric case */
+                
+                targ = &(frm.targets[cam][cpt_ix]);
+                targ->pnr = cpt_ix;
+                
+                vec_set(tmp, cpt_vert * 10, cpt_horz * 10, 0);
+                img_coord(tmp, calib[cam], &media_par, &(targ->x), &(targ->y));
+                metric_to_pixel(&(targ->x), &(targ->y), targ->x, targ->y, cpar);
+                
+                /* These values work in check_epi, so used here too */
+                targ->n = 25;
+                targ->nx = targ->ny = 5;
+                targ->sumg = 10;
+            }
+        }
+    }
+    vpar = read_volume_par("parameters/criteria.par");
+    corres_lists = correspondences(&frm, calib, vpar, cpar);
+    fail_unless(corres_lists[0] == NULL);
+    
+    for (subset_size = 2; subset_size <= num_cams; subset_size++) {
+        corres = corres_lists[subset_size - 1];
+        num_corres = 0;
+        
+        while (corres->corr >= 0) {
+            num_corres++;
+            corres++;
+        }
+        fail_unless(num_corres == ((subset_size == 4) ? 16 : 0));
+    }
+}
+END_TEST
 
 
 Suite* orient_suite(void) {
@@ -142,6 +214,11 @@ Suite* orient_suite(void) {
     tc = tcase_create ("quicksort_con");
     tcase_add_test(tc, test_quicksort_con);
     suite_add_tcase (s, tc);
+    
+    tc = tcase_create ("Calibration target correspondences");
+    tcase_add_test(tc, test_correspondences);
+    suite_add_tcase (s, tc);
+    
     return s;
 }
 


### PR DESCRIPTION
Take the correspondences code from openptv-python. Break it down. Clean it up. Test it. Fix it. 

Fixes to notice: 
(a) old code would permanently mark a target used even when the candidate clique failed on a target from another camera.
(b) reinstated consistent pairs.
(c) Properly stop generating candidates if scratch buffer is full. This used to segfault.

Bindings (to be done properly) will take some more time, as I need to think about the best way to do it Pythonically. I already used it in my own UI and it looks beautiful, but my bindings are not ready for prime-time. So let's focus on the C code for now. 