### PR TITLE
Solve of #111

### DIFF
--- a/liboptv/src/tracking_frame_buf.c
+++ b/liboptv/src/tracking_frame_buf.c
@@ -106,7 +106,11 @@ int write_targets(target buffer[], int num_targets, char* file_base, \
     int	tix, printf_ok, success = 0;
     char fileout[STR_MAX_LEN + 1];
     
-    sprintf(fileout, "%s%04d%s", file_base, frame_num, "_targets");
+    if (frame_num == 0){
+        sprintf(fileout, "%s%s", file_base, "_targets");
+    } else {
+        sprintf(fileout, "%s%04d%s", file_base, frame_num, "_targets");
+    }
 
     FILEOUT = fopen(fileout, "w");
     if (! FILEOUT) {


### PR DESCRIPTION
Solution to issue #111  

fixes the bug of writing targets during pre-processing when the frame is equal to 0. It's a special case sent by `openptv-python/jw_ptv.c` during the pre-processing. 

todo: never use frame number zero for the sequence loop or change zero to -999

@yosefm Please a quick review and merge for the sake of openptv-python users that are stuck in the wind tunnel :) 