### PR TITLE
Fix not setting tnr in targ_rec

### DIFF
--- a/liboptv/src/segmentation.c
+++ b/liboptv/src/segmentation.c
@@ -185,6 +185,7 @@ int targ_rec (unsigned char *img, target_par *targ_par, int xmin,
                     
                     pix[n_targets].x = x;
                     pix[n_targets].y = y;
+                    pix[n_targets].tnr = -1;
                     pix[n_targets].pnr = n_targets;
                     n_targets++;
                     
@@ -473,7 +474,6 @@ int ymin, int ymax, control_par *cpar, int num_cam, target pix[]){
           pix[n_target].nx = peaks[i].xmax - peaks[i].xmin + 1;
           pix[n_target].ny = peaks[i].ymax - peaks[i].ymin + 1;
           pix[n_target].tnr = -1;
-          // pix[n_target].pnr = n_target++;
           pix[n_target].pnr = n_target;
           n_target++;
         }

--- a/liboptv/src/segmentation.c
+++ b/liboptv/src/segmentation.c
@@ -185,7 +185,7 @@ int targ_rec (unsigned char *img, target_par *targ_par, int xmin,
                     
                     pix[n_targets].x = x;
                     pix[n_targets].y = y;
-                    pix[n_targets].tnr = -1;
+                    pix[n_targets].tnr = CORRES_NONE;
                     pix[n_targets].pnr = n_targets;
                     n_targets++;
                     
@@ -473,7 +473,7 @@ int ymin, int ymax, control_par *cpar, int num_cam, target pix[]){
           pix[n_target].n = peaks[i].n;
           pix[n_target].nx = peaks[i].xmax - peaks[i].xmin + 1;
           pix[n_target].ny = peaks[i].ymax - peaks[i].ymin + 1;
-          pix[n_target].tnr = -1;
+          pix[n_target].tnr = CORRES_NONE;
           pix[n_target].pnr = n_target;
           n_target++;
         }

--- a/liboptv/tests/check_segmentation.c
+++ b/liboptv/tests/check_segmentation.c
@@ -90,6 +90,7 @@ START_TEST(test_targ_rec)
     ntargets = targ_rec (img, &targ_par, 0, cpar.imx, 0, cpar.imy, &cpar, 0, pix);
     fail_unless(ntargets == 1);
     fail_unless(pix[0].n == 9);
+    fail_unless(pix[0].tnr == -1);
    
     /* test the two objects */
     unsigned char img1[5][5] = {

--- a/liboptv/tests/check_segmentation.c
+++ b/liboptv/tests/check_segmentation.c
@@ -90,7 +90,7 @@ START_TEST(test_targ_rec)
     ntargets = targ_rec (img, &targ_par, 0, cpar.imx, 0, cpar.imy, &cpar, 0, pix);
     fail_unless(ntargets == 1);
     fail_unless(pix[0].n == 9);
-    fail_unless(pix[0].tnr == -1);
+    fail_unless(pix[0].tnr == CORRES_NONE);
    
     /* test the two objects */
     unsigned char img1[5][5] = {


### PR DESCRIPTION
Very simple fix. Correspondence number for targets (``target.tnr``) should be a predefined negative value. peak_fit remmembered to set it, but targ_rec didn't. This affects the reporting of unused targets, but more importantly, I suspect it could cause some weirdness in linking trajectories (low probability).