### PR TITLE
fixed two problems spotted by Xcode:

### DIFF
--- a/liboptv/src/orientation.c
+++ b/liboptv/src/orientation.c
@@ -716,6 +716,7 @@ int read_man_ori_fix(vec3d fix4[4], char* calblock_filename,
 
     fpp = fopen(man_ori_filename,"r");
     if (! fpp) {
+        fix = (vec3d *) malloc(1); //otherwise we try to release a non existing object
         printf("Can't open manual orientation file %s\n", man_ori_filename);
         goto handle_error;
     }
@@ -744,7 +745,7 @@ int read_man_ori_fix(vec3d fix4[4], char* calblock_filename,
         if (num_match >= num_fix) break;
     }
     
-    free(fix);   
+    free(fix);
     return num_match;
 
 handle_error:

--- a/liboptv/src/segmentation.c
+++ b/liboptv/src/segmentation.c
@@ -93,7 +93,6 @@ int targ_rec (unsigned char *img, target_par *targ_par, int xmin,
       /* => local maximum, 'peak' */
           {
             yn=i;  xn=j;
-            xn = xn;
             sumg = gv;  *(img0 + i*imx + j) = 0;
             xa = xn;  xb = xn;  ya = yn;  yb = yn;
             gv -= thres;

--- a/liboptv/tests/check_segmentation.c
+++ b/liboptv/tests/check_segmentation.c
@@ -6,25 +6,31 @@
 
 
 START_TEST(test_peak_fit)
-{
-    int ntargets; 
-    unsigned char img[5][5] = {
+    {
+    int i,j, ntargets;
+    unsigned char tmpimg[5][5] = {
         { 0,   0,   0,   0, 0},
         { 0, 255, 255, 255, 0},
         { 0, 255, 255, 255, 0},
         { 0, 255, 255, 255, 0},
         { 0,   0,   0,   0, 0}
     };
-    
+
+
     target pix[1024];
-    
+
     control_par cpar = {
         .imx = 5,
         .imy = 5,
-    }; 
+    };
+
+    unsigned char* img;
+    img = calloc(cpar.imx*cpar.imy, sizeof(unsigned char));
+    for (i=0;i<cpar.imy;i++) for(j=0;j<cpar.imx;j++) {img[i*cpar.imx+j]=tmpimg[i][j];}
 
 
-    target_par targ_par= { 
+
+    target_par targ_par= {
         .gvthres = {250, 100, 20, 20}, 
         .discont = 5,
         .nnmin = 1, .nnmax = 10,
@@ -32,36 +38,41 @@ START_TEST(test_peak_fit)
         .nymin = 1, .nymax = 10, 
         .sumg_min = 12, 
         .cr_sz = 13 };
-    
+
                 
-   ntargets = peak_fit(img, &targ_par, 0, cpar.imx, 0, cpar.imy, &cpar, 0, pix);
-   fail_unless(ntargets == 1);
-   fail_unless(pix[0].n == 9);
-   
-   /* test the two objects */
-     unsigned char img1[5][5] = {
+    ntargets = peak_fit(img, &targ_par, 0, cpar.imx, 0, cpar.imy, &cpar, 0, pix);
+    fail_unless(ntargets == 1);
+    fail_unless(pix[0].n == 9);
+
+    /* test the two objects */
+     unsigned char tmpimg1[5][5] = {
         { 0,   0,   0,   0, 0},
         { 0, 255, 0, 0, 0},
         { 0, 0, 0, 0, 0},
         { 0, 0, 0, 251, 0},
         { 0,   0,   0,   0, 0}
     };
-   ntargets = peak_fit(img1, &targ_par, 0, cpar.imx, 0, cpar.imy, &cpar, 1, 
-        pix);
-   fail_unless(ntargets == 2);
-   
-   targ_par.gvthres[1] = 252; 
-   ntargets = peak_fit((unsigned char *)img1, &targ_par, 0, cpar.imx, 
-        0, cpar.imy, &cpar, 1, pix);
-   fail_unless(ntargets == 1);
 
-}
+    unsigned char* img1;
+    img1 = calloc(cpar.imx*cpar.imy, sizeof(unsigned char));
+    for (i=0;i<cpar.imy;i++) for(j=0;j<cpar.imx;j++) {img1[i*cpar.imx+j]=tmpimg1[i][j];}
+
+    ntargets = peak_fit(img1, &targ_par, 0, cpar.imx, 0, cpar.imy, &cpar, 1,
+        pix);
+    fail_unless(ntargets == 2);
+
+    targ_par.gvthres[1] = 252;
+    ntargets = peak_fit((unsigned char *)img1, &targ_par, 0, cpar.imx,
+        0, cpar.imy, &cpar, 1, pix);
+    fail_unless(ntargets == 1);
+
+    }
 END_TEST
 
 START_TEST(test_targ_rec)
 {
-    int ntargets; 
-    unsigned char img[5][5] = {
+    int i,j,ntargets;
+    unsigned char tmpimg[5][5] = {
         { 0,   0,   0,   0, 0},
         { 0, 255, 255, 255, 0},
         { 0, 255, 255, 255, 0},
@@ -86,21 +97,29 @@ START_TEST(test_targ_rec)
         .sumg_min = 12, 
         .cr_sz = 13 };
     
-                
+    unsigned char* img;
+    img = calloc(cpar.imx*cpar.imy, sizeof(unsigned char));
+    for (i=0;i<cpar.imy;i++) for(j=0;j<cpar.imx;j++) {img[i*cpar.imx+j]=tmpimg[i][j];}
+    
     ntargets = targ_rec (img, &targ_par, 0, cpar.imx, 0, cpar.imy, &cpar, 0, pix);
     fail_unless(ntargets == 1);
     fail_unless(pix[0].n == 9);
     fail_unless(pix[0].tnr == CORRES_NONE);
    
     /* test the two objects */
-    unsigned char img1[5][5] = {
+    unsigned char tmpimg1[5][5] = {
         { 0,   0,   0,   0, 0},
         { 0, 255, 0, 0, 0},
         { 0, 0, 0, 0, 0},
         { 0, 0, 0, 251, 0},
         { 0,   0,   0,   0, 0}
     };
-    ntargets = targ_rec (img1, &targ_par, 0, cpar.imx, 0, cpar.imy, &cpar, 1, 
+    
+    unsigned char* img1;
+    img1 = calloc(cpar.imx*cpar.imy, sizeof(unsigned char));
+    for (i=0;i<cpar.imy;i++) for(j=0;j<cpar.imx;j++) {img1[i*cpar.imx+j]=tmpimg1[i][j];}
+    
+    ntargets = targ_rec (img1, &targ_par, 0, cpar.imx, 0, cpar.imy, &cpar, 1,
         pix);
     fail_unless(ntargets == 2);
    
@@ -110,7 +129,7 @@ START_TEST(test_targ_rec)
     fail_unless(ntargets == 1);
 
     /* Trip a segfault writing over the edge. */
-    img1[4][4] = 255;
+    img1[4*cpar.imx+4] = 255;
     ntargets = targ_rec (img1, &targ_par, 0, cpar.imx, 0, cpar.imy, &cpar, 1,
         pix);
     /* If execution reached here, test passed. */


### PR DESCRIPTION
xn = xn in line 96 of segmentation
possible bus 10 cause by freeing unexacting memory of vec3d *fix
possible problem due to incompatible pointers, converting img[5][5] to *img using temporary arrays and a loop.