### PR TITLE
fix orientation bug in the missing pointer release 

### DIFF
--- a/liboptv/src/orientation.c
+++ b/liboptv/src/orientation.c
@@ -712,7 +712,7 @@ int read_man_ori_fix(vec3d fix4[4], char* calblock_filename,
     FILE* fpp;
     int	dummy, pnr, nr[4],i;
     int num_fix, num_match;
-    vec3d *fix;
+    vec3d *fix = NULL;
 
     fpp = fopen(man_ori_filename,"r");
     if (! fpp) {

--- a/liboptv/tests/check_orientation.c
+++ b/liboptv/tests/check_orientation.c
@@ -37,6 +37,12 @@ START_TEST(test_raw_orient)
     int eps, correct_eps = 25;
     double xp, yp;
     
+    
+    nfix = read_man_ori_fix(fix4, "testing_fodder/cal/calblock.txt",
+                                    "testing_fodder/parameters/wrong_man_ori.par", 0);
+    fail_unless(nfix == NULL);                                
+                                    
+    
     /* read 4 points manually selected from the calibration file */
     nfix = read_man_ori_fix(fix4, "testing_fodder/cal/calblock.txt",
                                     "testing_fodder/parameters/man_ori.par", 0);


### PR DESCRIPTION
added Yosef suggested fix to the missing pointer and added a test for it. At least on Mac, the test fails within the master branch with 

`
12: 80%: Checks: 5, Failures: 0, Errors: 1
12: /Users/alex/Documents/OpenPTV/alexlib/liboptv/tests/check_orientation.c:28:E:Raw orientation:test_raw_orient:0: (after this point) Received signal 6 (Abort trap: 6)
`