### PR TITLE
The actual fix for the problem with Qt4 on Ubuntu 16.04

### DIFF
--- a/liboptv/src/parameters.c
+++ b/liboptv/src/parameters.c
@@ -153,9 +153,7 @@ track_par* read_track_par(char *filename) {
 /* @WARNING: This is really important, some libraries (e.g. ROS, Qt4) seems to set the 
 system locale which takes decimal commata instead of points which causes the file input 
 parsing to fail */    
-    setlocale(LC_ALL, "C"); 
     setlocale(LC_NUMERIC,"C");
-    setlocale(LC_ALL, "POSIX");
     
     fpp = fopen(filename, "r");
     if(fscanf(fpp, "%lf\n", &(ret->dvxmin)) == 0) goto handle_error;
@@ -226,9 +224,7 @@ volume_par* read_volume_par(char *filename) {
 /* @WARNING: This is really important, some libraries (e.g. ROS, Qt4) seems to set the 
 system locale which takes decimal commata instead of points which causes the file input 
 parsing to fail */
-    setlocale(LC_ALL, "C"); 
     setlocale(LC_NUMERIC,"C");
-    setlocale(LC_ALL, "POSIX");
     
     fpp = fopen(filename, "r");
     if(fscanf(fpp, "%lf\n", &(ret->X_lay[0])) == 0) goto handle_error;
@@ -348,9 +344,7 @@ control_par* read_control_par(char *filename) {
 /* @WARNING: This is really important, some libraries (e.g. ROS, Qt4) seems to set the 
 system locale which takes decimal commata instead of points which causes the file input 
 parsing to fail */
-    setlocale(LC_ALL, "C"); // Do not use the system locale
     setlocale(LC_NUMERIC,"C");
-    setlocale(LC_ALL, "POSIX");
 
     if ((par_file = fopen(filename, "r")) == NULL) {
         printf("Could not open file %s", filename);

--- a/liboptv/src/parameters.c
+++ b/liboptv/src/parameters.c
@@ -4,6 +4,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <locale.h>
+
+
 
 /* read_sequence_par() reads sequence parameters from a config file with the
    following format: each line is a value, first num_cams values are image 
@@ -147,6 +150,13 @@ track_par* read_track_par(char *filename) {
     FILE* fpp;
     track_par *ret = (track_par *) malloc(sizeof(track_par));
     
+/* @WARNING: This is really important, some libraries (e.g. ROS, Qt4) seems to set the 
+system locale which takes decimal commata instead of points which causes the file input 
+parsing to fail */    
+    setlocale(LC_ALL, "C"); 
+    setlocale(LC_NUMERIC,"C");
+    setlocale(LC_ALL, "POSIX");
+    
     fpp = fopen(filename, "r");
     if(fscanf(fpp, "%lf\n", &(ret->dvxmin)) == 0) goto handle_error;
     if(fscanf(fpp, "%lf\n", &(ret->dvxmax)) == 0) goto handle_error;
@@ -212,6 +222,13 @@ int compare_track_par(track_par *t1, track_par *t2) {
 volume_par* read_volume_par(char *filename) {
     FILE* fpp;
     volume_par *ret = (volume_par *) malloc(sizeof(volume_par));
+
+/* @WARNING: This is really important, some libraries (e.g. ROS, Qt4) seems to set the 
+system locale which takes decimal commata instead of points which causes the file input 
+parsing to fail */
+    setlocale(LC_ALL, "C"); 
+    setlocale(LC_NUMERIC,"C");
+    setlocale(LC_ALL, "POSIX");
     
     fpp = fopen(filename, "r");
     if(fscanf(fpp, "%lf\n", &(ret->X_lay[0])) == 0) goto handle_error;
@@ -327,6 +344,13 @@ control_par* read_control_par(char *filename) {
     int cam;
     int num_cams;
     control_par *ret;
+
+/* @WARNING: This is really important, some libraries (e.g. ROS, Qt4) seems to set the 
+system locale which takes decimal commata instead of points which causes the file input 
+parsing to fail */
+    setlocale(LC_ALL, "C"); // Do not use the system locale
+    setlocale(LC_NUMERIC,"C");
+    setlocale(LC_ALL, "POSIX");
 
     if ((par_file = fopen(filename, "r")) == NULL) {
         printf("Could not open file %s", filename);
@@ -459,7 +483,8 @@ int compare_mm_np(mm_np *mm_np1, mm_np *mm_np2)
 }
 
 /* Reads target recognition parameters from file.
- * Parameter: filename - the absolute/relative path to file from which the parameters will be read.
+ * Parameter: filename - the absolute/relative path to file from which the parameters 
+              will be read.
  * Returns: pointer to a new target_par structure.
  */
 target_par* read_target_par(char *filename) {


### PR DESCRIPTION
Lukas has experienced a lot of problems with Qt4 installation lately on Ubuntu [forum](https://groups.google.com/forum/#!topic/openptv/LFIxfeecjDM) including problems with PBI [forum](https://groups.google.com/forum/#!topic/openptv/KCWfrmKg0XU) that all somehow linked to Qt4. The installations with wxPython worked, but not those with Qt4. 
After a long and tedious search with gdb I've found that read_control_par reads floating numbers incorrectly, returning 0,000 instead of a floating 0.012 and this happens only after 
`export ETS_TOOLKIT=qt4`

So I've found this one [stackoverflow answer](https://stackoverflow.com/questions/20555696/why-does-qt-change-behaviour-of-sscanf) that had the right answer: 

`#include <locale.h>`

and in the places where doubles are scanned `fscanf(file,'%lf\n',variable);` add before that

`setlocale(LC_NUMERIC,"C")`

after a search on github I found that people also recommend adding `LC_ALL`. So that's what is working now. 

It seems to be a critical bug and I'd appreciate a quick review. 