### PR TITLE
 include pyface Qt4 to test the locale bug

### DIFF
--- a/py_bind/test/test_parameters_bindings.py
+++ b/py_bind/test/test_parameters_bindings.py
@@ -5,6 +5,10 @@ from optv.parameters import MultimediaParams, ControlParams, VolumeParams, \
 import numpy, os, shutil
 from numpy import r_
 
+from pyface.api import GUI
+from traits.etsconfig.api import ETSConfig
+ETSConfig.toolkit = 'qt4'
+
 class Test_MultimediaParams(unittest.TestCase):
     def test_mm_np_instantiation(self):
         


### PR DESCRIPTION
I suggest to modify the test by including Qt4 bindings and failing the test if the locale.h is not resolved.