### PR TITLE
Break backward compatibility in ptv.par reading

### DIFF
--- a/liboptv/src/parameters.c
+++ b/liboptv/src/parameters.c
@@ -364,12 +364,6 @@ parsing to fail */
         strncpy(ret->cal_img_base_name[cam], line, SEQ_FNAME_MAX_LEN);
     }
     
-    /*  backward compatibility: Tcl/Tk version will look for 8 rows of strings 
-        regardless of camera count.
-    */
-    for (cam = 0; cam < 2*(4 - ret->num_cams); cam++) {
-        if (fscanf(par_file, "%s\n", line) == 0) goto handle_error; 
-    }
     
     if(fscanf(par_file, "%d\n", &(ret->hp_flag)) == 0) goto handle_error;
     if(fscanf(par_file, "%d\n", &(ret->allCam_flag)) == 0) goto handle_error;

--- a/liboptv/tests/testing_fodder/track/parameters/control_newpart.par
+++ b/liboptv/tests/testing_fodder/track/parameters/control_newpart.par
@@ -5,8 +5,6 @@ img/cam2.10099
 cal/cam2.tif
 img/cam2.10018
 cal/cam2.tif
-img/cam2.10018
-cal/cam2.tif
 1
 0
 1

--- a/liboptv/tests/testing_fodder/track/parameters/ptv.par
+++ b/liboptv/tests/testing_fodder/track/parameters/ptv.par
@@ -3,10 +3,6 @@ img/cam1.10099
 cal/cam1.tif
 img/cam2.10099
 cal/cam2.tif
-img/cam2.10018
-cal/cam2.tif
-img/cam2.10018
-cal/cam2.tif
 1
 0
 1


### PR DESCRIPTION
Since Tcl/Tk version is not used anymore and the only use for the moment is through Python, either in `pbi` or `pyptv`, it makes sense to remove the obsolete backward compatibility and leave in ptv.par only the relevant number of lines. 