### PR TITLE
solves bug for 2-3 camera cases

### DIFF
--- a/py_bind/optv/correspondences.pyx
+++ b/py_bind/optv/correspondences.pyx
@@ -165,8 +165,6 @@ def correspondences(list img_pts, list flat_coords, list cals,
     frm.targets = <target**> calloc(num_cams, sizeof(target*))
     frm.num_targets = <int *> calloc(num_cams, sizeof(int))
     
-    print(num_cams)
-
     for cam in range(num_cams):
         calib[cam] = (<Calibration>cals[cam])._calibration
         frm.targets[cam] = (<TargetArray>img_pts[cam])._tarr
@@ -184,7 +182,6 @@ def correspondences(list img_pts, list flat_coords, list cals,
     
     for clique_type in xrange(num_cams - 1): 
         num_points = match_counts[4 - num_cams + clique_type] # for 1-4 cameras
-        print(num_points,clique_type)
         clique_targs = np.full((num_cams, num_points, 2), PT_UNUSED, 
             dtype=np.float64)
         clique_ids = np.full((num_cams, num_points), CORRES_NONE, 

--- a/py_bind/optv/correspondences.pyx
+++ b/py_bind/optv/correspondences.pyx
@@ -166,6 +166,8 @@ def correspondences(list img_pts, list flat_coords, list cals,
     frm.targets = <target**> calloc(num_cams, sizeof(target*))
     frm.num_targets = <int *> calloc(num_cams, sizeof(int))
     
+    print(num_cams)
+
     for cam in range(num_cams):
         calib[cam] = (<Calibration>cals[cam])._calibration
         frm.targets[cam] = (<TargetArray>img_pts[cam])._tarr
@@ -183,6 +185,7 @@ def correspondences(list img_pts, list flat_coords, list cals,
     
     for clique_type in xrange(num_cams - 1):
         num_points = match_counts[clique_type]
+        print(num_points,clique_type)
         clique_targs = np.full((num_cams, num_points, 2), PT_UNUSED, 
             dtype=np.float64)
         clique_ids = np.full((num_cams, num_points), CORRES_NONE, 

--- a/py_bind/optv/correspondences.pyx
+++ b/py_bind/optv/correspondences.pyx
@@ -146,7 +146,6 @@ def correspondences(list img_pts, list flat_coords, list cals,
         previous 3).
     """
     cdef:
-        int pt, cam
         int num_cams = len(cals)
         
         calibration **calib = <calibration **> malloc(
@@ -183,8 +182,8 @@ def correspondences(list img_pts, list flat_coords, list cals,
     sorted_corresp = [None]*(num_cams - 1)
     last_count = 0
     
-    for clique_type in xrange(num_cams - 1):
-        num_points = match_counts[clique_type]
+    for clique_type in xrange(num_cams - 1): 
+        num_points = match_counts[4 - num_cams + clique_type] # for 1-4 cameras
         print(num_points,clique_type)
         clique_targs = np.full((num_cams, num_points, 2), PT_UNUSED, 
             dtype=np.float64)


### PR DESCRIPTION
correspondences.c from liboptv always returns 4 values for match_counts, ordered from quarduplets. We didn't think about this case in correspondences.pyx and clique_type were numbered wrong way. 

this should fix the bug reported in https://github.com/alexlib/pyptv/issues/9 and also in https://github.com/yosefm/pbi/issues/6  @yosefm 