### PR TITLE
suggest to change Error to Warning 

### DIFF
--- a/py_bind/optv/orientation.pyx
+++ b/py_bind/optv/orientation.pyx
@@ -36,7 +36,7 @@ def match_detection_to_ref(Calibration cal,
     """
 
     if len(img_pts) < len(ref_pts):
-        raise ValueError('Must have at least as many targets as ref. points.')
+        print('Warning: there are not as many targets as ref. points.')
 
     cdef:
         vec3d *ref_coord


### PR DESCRIPTION
for the case where number of targets is not as the number of reference points. This was working before in liboptv without this constraints. It was entered when PBI was developed probably, but not clear if this is the best use of it. Since in pyptv we have a single calblock.txt for the 4 cameras, it's impossible to change it for each camera case