### PR TITLE
0.2.7.b

### DIFF
--- a/liboptv/src/segmentation.c
+++ b/liboptv/src/segmentation.c
@@ -65,9 +65,13 @@ int targ_rec (unsigned char *img, target_par *targ_par, int xmin,
     thres = targ_par->gvthres[num_cam];
     disco = targ_par->discont;
     
+    // printf("thres %d disco %d \n", thres, disco);
+
     /* copy image to a temporary mask */
     img0 = (unsigned char *) calloc (imx*imy, 1);
     memcpy(img0, img, imx*imy);
+
+    // printf("in segmentation.c memcpy succeded\n");
 
     /* Make sure the min/max coordinates don't cause us to access memory
        outside the image memory.
@@ -191,10 +195,24 @@ int targ_rec (unsigned char *img, target_par *targ_par, int xmin,
                     
                     xn = x;  
                     yn = y;
+                    // printf("%d %d %d \n",n_targets, xn, yn);
               }
           } /*  end of if-loop  */
     }
     free(img0);
+    /* protect pix from zero memory */
+    if (n_targets < 1){
+        pix[0].n = 1;
+        pix[0].nx = 1;
+        pix[0].ny = 1;
+        pix[0].sumg = 1;
+        pix[0].x = 1;
+        pix[0].y = 1;
+        pix[0].tnr = CORRES_NONE;
+        pix[0].pnr = 1;
+        n_targets++;
+    }
+    // printf("final n_targets %d\n",n_targets);
     return(n_targets);
 }
 

--- a/py_bind/optv/segmentation.pyx
+++ b/py_bind/optv/segmentation.pyx
@@ -73,9 +73,6 @@ def target_recognition(np.ndarray[np.uint8_t, ndim=2] img, TargetParams tpar, in
 
     assert img.dtype == DTYPE
 
-    printf("subrange %d %d %d %d \n", xmin, xmax, ymin, ymax);
-
-
     # The core liboptv call:
     num_targs = targ_rec(<unsigned char *>img.data, tpar._targ_par, 
         xmin, xmax, ymin, ymax, cparam._control_par, cam, targs)

--- a/py_bind/setup.py
+++ b/py_bind/setup.py
@@ -156,7 +156,7 @@ setup(
     },
     version='0.2.7b',
     install_requires=[
-        'numpy',
+        'numpy<1.24',
         'pyyaml',
     ],
     setup_requires=['numpy'],

--- a/py_bind/setup.py
+++ b/py_bind/setup.py
@@ -8,7 +8,7 @@ import sys
 import glob
 from setuptools import Extension
 from setuptools.command.build_ext import build_ext
-import imp
+import importlib
 
 
 class PrepareCommand(setuptools.Command):
@@ -80,9 +80,9 @@ class BuildExt(build_ext, object):
             import builtins
             if hasattr(builtins, '__NUMPY_SETUP__'):
                 del builtins.__NUMPY_SETUP__
-            import imp
+            import importlib
             import numpy
-            imp.reload(numpy)
+            importlib.reload(numpy)
         else:
             import builtins
             if hasattr(__builtin__, '__NUMPY_SETUP__'):
@@ -154,7 +154,7 @@ setup(
     package_data={
         'optv': ['*.pxd', '*.c', '*.h'],
     },
-    version='0.2.7',
+    version='0.2.7b',
     install_requires=[
         'numpy',
         'pyyaml',


### PR DESCRIPTION
this pull request solves 3 problems:
- recent numpy 1.24 breaks some stuff so it has to be `<1.24` for compatibility with pyptv
- segmentation.pyx and segmentation.c have double check that image type and targ pix is are not faulty 