### PR TITLE
Update lsqadj.c

### DIFF
--- a/liboptv/src/lsqadj.c
+++ b/liboptv/src/lsqadj.c
@@ -29,9 +29,9 @@ void ata (double *a, double *ata, int m, int n, int n_large ) {
     {
       for (j = 0; j < n; j++)
     {
-      *(ata+i*n_large+j) = 0.0;
+      *(ata+i*n+j) = 0.0;
       for (k = 0; k < m; k++)
-        *(ata+i*n_large+j) +=  *(a+k*n_large+i)  * *(a+k*n_large+j);
+        *(ata+i*n+j) +=  *(a+k*n_large+i)  * *(a+k*n_large+j);
     }
     }
 }


### PR DESCRIPTION
long time bug that was not tested properly because in all liboptv we never used submatrix multiplication. so n == n_large in practice, but for n < n_large this is wrong.  fixed it due to the thorough testing in Python